### PR TITLE
Trigger publish.yml on tag push, not just release-published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to PyPI
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   release:
     types: [published]
   workflow_dispatch:
@@ -34,6 +37,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+
+      - name: Verify tag matches pyproject.toml version
+        if: github.event_name == 'push'
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ "${TAG}" != "${PYPROJECT_VERSION}" ]; then
+            echo "Error: Tag version (${TAG}) does not match pyproject.toml version (${PYPROJECT_VERSION})"
+            exit 1
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2


### PR DESCRIPTION
## Summary
Every historical \`Publish to PyPI\` run was triggered manually via \`workflow_dispatch\`; the one time the \`release: published\` event actually fired, it failed. This is expected: \`Create Release\` uses the built-in \`GITHUB_TOKEN\`, and GitHub Actions blocks \`GITHUB_TOKEN\`-authored events from triggering other workflows (loop prevention).

Added a direct \`push: tags: v*.*.*\` trigger plus a tag/pyproject.toml version guard, matching the other chuk-* repos, so releases publish automatically instead of requiring a manual dispatch each time.

Note: I don't have admin rights on this repo, so I couldn't create the branch-restricted \`pypi\` GitHub Environment or a branch-protection ruleset (both done on the other chuk-* repos). Someone with admin access should do that separately if desired.

## Test plan
- [x] \`uv run pytest\` — 2467 passed, 17 skipped
- [ ] CI green on this PR