### PR TITLE
Enforce OAuth client authentication at the token endpoint

### DIFF
--- a/docs/oauth/custom-providers.md
+++ b/docs/oauth/custom-providers.md
@@ -305,9 +305,33 @@ must hold up its end of what the server's RFC 8414 metadata advertises:
 - **Never let a PKCE challenge go unverified.** If a code carries a
   `code_challenge`, the token exchange must verify it — RFC 7636 §4.3 says an
   absent `code_challenge_method` means `plain`, not "skip the check".
+- **Validate redirect URIs at registration.** Use
+  `chuk_mcp_server.oauth.redirect_uri.is_safe_redirect_uri()` to reject
+  `javascript:`, `data:` and relative URIs. Registration is open, and the
+  callback page renders the registered URI as a link.
+- **Report the real token lifetime.** `expires_in` must match the TTL your token
+  store applies, or clients will cache tokens past their expiry.
 
 Raise `TokenError(error="invalid_client", ...)` when authentication fails; the
 middleware turns that into a `401` with a `WWW-Authenticate: Basic` header.
+
+### `validate_redirect_uri`
+
+Before the authorization endpoint redirects an *error* back to a client, it asks
+your provider whether the redirect URI is actually registered — RFC 6749 §4.1.2.1
+forbids automatically navigating to an unvalidated URI. The default
+implementation on `BaseOAuthProvider` answers from `self.token_store`, so the
+documented provider pattern needs no extra work. Override it if you store
+clients elsewhere:
+
+```python
+    async def validate_redirect_uri(self, client_id: str, redirect_uri: str) -> bool:
+        client = await my_client_registry.get(client_id)
+        return bool(client and redirect_uri in client.redirect_uris)
+```
+
+Returning `False` is always safe: the error is rendered as a page instead of
+being redirected. A provider that cannot answer **must** return `False`.
 
 ## Service OAuth Client
 

--- a/docs/oauth/custom-providers.md
+++ b/docs/oauth/custom-providers.md
@@ -141,8 +141,22 @@ class MyServiceProvider(BaseOAuthProvider):
         client_id: str,
         redirect_uri: str,
         code_verifier: str | None = None,
+        client_secret: str | None = None,
     ) -> OAuthToken:
         """Exchange authorization code for access token."""
+        # Authenticate the client FIRST (RFC 6749 §3.2.1). authenticate_client
+        # requires a secret from clients that registered as client_secret_post or
+        # client_secret_basic, and rejects a wrong secret from any client.
+        if not await self.token_store.authenticate_client(
+            client_id,
+            client_secret=client_secret,
+        ):
+            from chuk_mcp_server.oauth.models import TokenError
+            raise TokenError(
+                error="invalid_client",
+                error_description="Client authentication failed",
+            )
+
         # Validate code
         code_data = await self.token_store.validate_authorization_code(
             code=code,
@@ -174,9 +188,25 @@ class MyServiceProvider(BaseOAuthProvider):
         )
 
     async def exchange_refresh_token(
-        self, refresh_token: str, client_id: str, scope: str | None = None
+        self,
+        refresh_token: str,
+        client_id: str,
+        scope: str | None = None,
+        client_secret: str | None = None,
     ) -> OAuthToken:
         """Refresh an access token."""
+        # Authenticate the client, then pass client_id to the store so a leaked
+        # refresh token cannot be redeemed by a different client (RFC 6749 §6).
+        if not await self.token_store.authenticate_client(
+            client_id,
+            client_secret=client_secret,
+        ):
+            from chuk_mcp_server.oauth.models import TokenError
+            raise TokenError(
+                error="invalid_client",
+                error_description="Client authentication failed",
+            )
+
         # Get refresh token data
         token_data = await self.token_store.get_refresh_token_data(
             refresh_token, client_id
@@ -238,18 +268,46 @@ class MyServiceProvider(BaseOAuthProvider):
         self, client_metadata: dict[str, Any]
     ) -> OAuthClientInfo:
         """Register a new MCP client."""
-        client_id, client_secret = await self.token_store.register_client(
+        # Honour the client's RFC 7591 token_endpoint_auth_method declaration.
+        # Dropping it would leave a confidential client's secret unenforceable.
+        auth_method = client_metadata.get("token_endpoint_auth_method", "none")
+
+        credentials = await self.token_store.register_client(
             client_name=client_metadata.get("client_name", "Unknown"),
             redirect_uris=client_metadata.get("redirect_uris", []),
+            token_endpoint_auth_method=auth_method,
         )
 
         return OAuthClientInfo(
-            client_id=client_id,
-            client_secret=client_secret,
+            client_id=credentials["client_id"],
+            client_secret=credentials["client_secret"],
             client_name=client_metadata.get("client_name", "Unknown"),
             redirect_uris=client_metadata.get("redirect_uris", []),
+            token_endpoint_auth_method=auth_method,
         )
 ```
+
+### Client authentication requirements
+
+Anything you build on `BaseOAuthProvider` is an OAuth Authorization Server, so it
+must hold up its end of what the server's RFC 8414 metadata advertises:
+
+- **Authenticate the client at the token endpoint before honouring a grant.** The
+  middleware extracts `client_secret` from either the request body
+  (`client_secret_post`) or an `Authorization: Basic` header
+  (`client_secret_basic`) and passes it to your provider. Check it with
+  `token_store.authenticate_client()`, which requires a secret from clients that
+  registered as confidential and rejects a wrong secret from anyone.
+- **Persist the client's declared `token_endpoint_auth_method`.** A secret you
+  issue but never record a requirement for is a secret you can never enforce.
+- **Bind refresh tokens to their client.** Pass `client_id` to
+  `token_store.refresh_access_token()` so a leaked token is useless to anyone else.
+- **Never let a PKCE challenge go unverified.** If a code carries a
+  `code_challenge`, the token exchange must verify it — RFC 7636 §4.3 says an
+  absent `code_challenge_method` means `plain`, not "skip the check".
+
+Raise `TokenError(error="invalid_client", ...)` when authentication fails; the
+middleware turns that into a `401` with a `WWW-Authenticate: Basic` header.
 
 ## Service OAuth Client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chuk-mcp-server"
-version = "0.25.6"
+version = "0.26.0"
 description = "A developer-friendly MCP framework powered by chuk_mcp"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ google_drive = [
     "google-auth-oauthlib>=1.1.0",
     "google-auth-httplib2>=0.1.1",
     "google-api-python-client>=2.100.0",
+    # Transitive via google-auth -> pyasn1-modules. Floor set explicitly for
+    # CVE-2026-59885 and CVE-2026-59886.
+    "pyasn1>=0.6.4",
 ]
 monitoring = [
     "psutil>=7.0.0",

--- a/src/chuk_mcp_server/oauth/__init__.py
+++ b/src/chuk_mcp_server/oauth/__init__.py
@@ -30,6 +30,8 @@ Usage:
 
 from .base_provider import BaseOAuthProvider
 from .base_token_store import BaseTokenStore
+from .compat import supports_keyword
+from .crypto import secure_compare
 from .helpers import configure_storage_from_oauth, setup_google_drive_oauth
 from .middleware import OAuthMiddleware
 from .models import (
@@ -40,6 +42,7 @@ from .models import (
     RegistrationError,
     TokenError,
 )
+from .redirect_uri import build_redirect_url, is_safe_redirect_uri
 from .token_store import TokenStore
 
 __all__ = [
@@ -55,4 +58,9 @@ __all__ = [
     "BaseTokenStore",
     "setup_google_drive_oauth",
     "configure_storage_from_oauth",
+    # Helpers for provider authors
+    "supports_keyword",
+    "secure_compare",
+    "is_safe_redirect_uri",
+    "build_redirect_url",
 ]

--- a/src/chuk_mcp_server/oauth/base_provider.py
+++ b/src/chuk_mcp_server/oauth/base_provider.py
@@ -48,15 +48,23 @@ class BaseOAuthProvider(ABC):
         client_id: str,
         redirect_uri: str,
         code_verifier: str | None = None,
+        client_secret: str | None = None,
     ) -> OAuthToken:
         """
         Exchange authorization code for access token.
+
+        Implementations MUST authenticate the client when it registered with a
+        confidential token_endpoint_auth_method (client_secret_post or
+        client_secret_basic) — see RFC 6749 section 3.2.1. Public clients
+        register as "none" and may exchange without a secret.
 
         Args:
             code: Authorization code
             client_id: Client ID
             redirect_uri: Redirect URI (must match)
             code_verifier: PKCE code verifier
+            client_secret: Client secret presented at the token endpoint, from
+                either the request body or an Authorization: Basic header
 
         Returns:
             OAuth token
@@ -72,14 +80,20 @@ class BaseOAuthProvider(ABC):
         refresh_token: str,
         client_id: str,
         scope: str | None = None,
+        client_secret: str | None = None,
     ) -> OAuthToken:
         """
         Refresh access token using refresh token.
+
+        Implementations MUST authenticate confidential clients (RFC 6749
+        section 6) and MUST reject a refresh token that was issued to a
+        different client than the one presenting it.
 
         Args:
             refresh_token: Refresh token
             client_id: Client ID
             scope: Optional scope (must be subset of original)
+            client_secret: Client secret presented at the token endpoint
 
         Returns:
             New OAuth token

--- a/src/chuk_mcp_server/oauth/base_provider.py
+++ b/src/chuk_mcp_server/oauth/base_provider.py
@@ -141,6 +141,40 @@ class BaseOAuthProvider(ABC):
         """
         pass
 
+    async def validate_redirect_uri(
+        self,
+        client_id: str,
+        redirect_uri: str,
+    ) -> bool:
+        """
+        Report whether redirect_uri is registered for client_id.
+
+        The authorization endpoint calls this *before* redirecting an error back
+        to the client. RFC 6749 section 4.1.2.1 forbids redirecting to an
+        unvalidated URI, so a provider that cannot answer must answer False and
+        the error is rendered as a page instead.
+
+        The default delegates to ``self.token_store.validate_client`` when the
+        provider has one, which covers the documented provider pattern. Override
+        it if your provider stores clients elsewhere.
+
+        Args:
+            client_id: Client ID from the authorization request
+            redirect_uri: Redirect URI from the authorization request
+
+        Returns:
+            True only if the pairing is known to be registered
+        """
+        token_store = getattr(self, "token_store", None)
+        if token_store is None:
+            return False
+
+        try:
+            return bool(await token_store.validate_client(client_id, redirect_uri=redirect_uri))
+        except Exception:
+            # An unanswerable check is a failed check.
+            return False
+
     async def revoke_token(
         self,
         token: str,

--- a/src/chuk_mcp_server/oauth/base_token_store.py
+++ b/src/chuk_mcp_server/oauth/base_token_store.py
@@ -7,6 +7,8 @@ Defines the interface that all token store implementations must follow.
 from abc import ABC, abstractmethod
 from typing import Any
 
+from .constants import DEFAULT_AUTH_METHOD
+
 
 class BaseTokenStore(ABC):
     """
@@ -63,8 +65,18 @@ class BaseTokenStore(ABC):
         pass
 
     @abstractmethod
-    async def refresh_access_token(self, refresh_token: str) -> tuple[str, str] | None:
-        """Refresh MCP access token using refresh token."""
+    async def refresh_access_token(
+        self,
+        refresh_token: str,
+        client_id: str | None = None,
+    ) -> tuple[str, str] | None:
+        """
+        Refresh MCP access token using refresh token.
+
+        When ``client_id`` is supplied it must match the client the refresh token
+        was issued to (RFC 6749 section 6). It is optional so that token stores
+        written against an earlier release keep working.
+        """
         pass
 
     # ============================================================================
@@ -114,8 +126,15 @@ class BaseTokenStore(ABC):
         self,
         client_name: str,
         redirect_uris: list[str],
+        token_endpoint_auth_method: str = DEFAULT_AUTH_METHOD,
     ) -> dict[str, str]:
-        """Register a new MCP client."""
+        """
+        Register a new MCP client.
+
+        ``token_endpoint_auth_method`` is the RFC 7591 declaration of how the
+        client will authenticate at the token endpoint. It has a default so that
+        token stores written against an earlier release keep working.
+        """
         pass
 
     @abstractmethod
@@ -125,5 +144,25 @@ class BaseTokenStore(ABC):
         client_secret: str | None = None,
         redirect_uri: str | None = None,
     ) -> bool:
-        """Validate MCP client credentials."""
+        """Validate MCP client credentials, checking the secret only if supplied."""
         pass
+
+    async def authenticate_client(
+        self,
+        client_id: str,
+        client_secret: str | None = None,
+        redirect_uri: str | None = None,
+    ) -> bool:
+        """
+        Authenticate a client at the token endpoint (RFC 6749 section 3.2.1).
+
+        Implementations that persist a client's registered
+        token_endpoint_auth_method should override this to require a secret from
+        confidential clients. The default delegates to :meth:`validate_client`,
+        which preserves the behaviour of stores that do not track the method.
+        """
+        return await self.validate_client(
+            client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+        )

--- a/src/chuk_mcp_server/oauth/client_auth.py
+++ b/src/chuk_mcp_server/oauth/client_auth.py
@@ -1,0 +1,131 @@
+"""
+Client credential extraction for the OAuth token endpoint.
+
+RFC 6749 section 2.3.1 defines two ways a client may authenticate at the token
+endpoint: an ``Authorization: Basic`` header (``client_secret_basic``) or
+credentials in the request body (``client_secret_post``). This module turns
+either form into a single ``ClientCredentials`` value, and reports the ways the
+two can disagree so the caller can reject the request instead of guessing.
+"""
+
+import base64
+import binascii
+from dataclasses import dataclass
+from enum import Enum
+from urllib.parse import unquote
+
+from .constants import (
+    AUTH_SCHEME_BASIC,
+    BASIC_CREDENTIALS_SEPARATOR,
+)
+
+
+class CredentialError(Enum):
+    """Why a set of presented client credentials could not be accepted."""
+
+    MALFORMED_HEADER = "malformed_header"
+    CLIENT_ID_MISMATCH = "client_id_mismatch"
+    CLIENT_SECRET_MISMATCH = "client_secret_mismatch"
+
+
+@dataclass(frozen=True)
+class ClientCredentials:
+    """Client credentials presented at the token endpoint."""
+
+    client_id: str | None = None
+    client_secret: str | None = None
+    error: CredentialError | None = None
+
+    @property
+    def is_valid(self) -> bool:
+        """True when the presented credentials are internally consistent."""
+        return self.error is None
+
+
+def parse_basic_auth(header_value: str | None) -> tuple[str | None, str | None]:
+    """
+    Parse an ``Authorization: Basic`` header into (client_id, client_secret).
+
+    Per RFC 6749 section 2.3.1 both halves are form-urlencoded before being
+    base64'd, so they are unquoted here.
+
+    Args:
+        header_value: Raw Authorization header value, or None
+
+    Returns:
+        (client_id, client_secret), both None when the header is absent or uses
+        a different scheme
+
+    Raises:
+        ValueError: If the header claims Basic but cannot be decoded
+    """
+    if not header_value:
+        return None, None
+
+    scheme, _, encoded = header_value.partition(" ")
+    if scheme.lower() != AUTH_SCHEME_BASIC:
+        # Some other scheme (e.g. Bearer) — not client authentication.
+        return None, None
+
+    encoded = encoded.strip()
+    if not encoded:
+        raise ValueError("Basic credentials missing")
+
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError) as exc:
+        raise ValueError("Basic credentials are not valid base64") from exc
+
+    if BASIC_CREDENTIALS_SEPARATOR not in decoded:
+        raise ValueError("Basic credentials must be client_id:client_secret")
+
+    client_id, _, client_secret = decoded.partition(BASIC_CREDENTIALS_SEPARATOR)
+    if not client_id:
+        raise ValueError("Basic credentials missing client_id")
+
+    return unquote(client_id), unquote(client_secret)
+
+
+def extract_client_credentials(
+    header_value: str | None,
+    body_client_id: str | None,
+    body_client_secret: str | None,
+) -> ClientCredentials:
+    """
+    Resolve the client credentials for a token request.
+
+    Header credentials take precedence, but a body value that contradicts the
+    header is an error rather than something to silently drop.
+
+    Args:
+        header_value: Raw Authorization header value, or None
+        body_client_id: client_id from the request body, or None
+        body_client_secret: client_secret from the request body, or None
+
+    Returns:
+        The resolved credentials, or one carrying an ``error``
+    """
+    try:
+        header_client_id, header_client_secret = parse_basic_auth(header_value)
+    except ValueError:
+        return ClientCredentials(error=CredentialError.MALFORMED_HEADER)
+
+    if header_client_id is not None and body_client_id and body_client_id != header_client_id:
+        return ClientCredentials(error=CredentialError.CLIENT_ID_MISMATCH)
+
+    if header_client_secret and body_client_secret and body_client_secret != header_client_secret:
+        return ClientCredentials(error=CredentialError.CLIENT_SECRET_MISMATCH)
+
+    return ClientCredentials(
+        client_id=header_client_id or body_client_id,
+        # An empty secret carries no proof of anything; treat it as absent.
+        client_secret=header_client_secret or body_client_secret or None,
+    )
+
+
+__all__ = [
+    "ClientCredentials",
+    "CredentialError",
+    "extract_client_credentials",
+    "parse_basic_auth",
+]

--- a/src/chuk_mcp_server/oauth/client_auth.py
+++ b/src/chuk_mcp_server/oauth/client_auth.py
@@ -12,7 +12,7 @@ import base64
 import binascii
 from dataclasses import dataclass
 from enum import Enum
-from urllib.parse import unquote
+from urllib.parse import unquote_plus
 
 from .constants import (
     AUTH_SCHEME_BASIC,
@@ -83,7 +83,9 @@ def parse_basic_auth(header_value: str | None) -> tuple[str | None, str | None]:
     if not client_id:
         raise ValueError("Basic credentials missing client_id")
 
-    return unquote(client_id), unquote(client_secret)
+    # RFC 6749 2.3.1 applies application/x-www-form-urlencoded, which encodes
+    # space as "+" — so unquote_plus, not unquote.
+    return unquote_plus(client_id), unquote_plus(client_secret)
 
 
 def extract_client_credentials(

--- a/src/chuk_mcp_server/oauth/compat.py
+++ b/src/chuk_mcp_server/oauth/compat.py
@@ -1,0 +1,49 @@
+"""
+Backwards-compatibility helpers for OAuth extension points.
+
+``BaseOAuthProvider`` and ``BaseTokenStore`` are documented extension points, so
+implementations written against an older release will not accept keyword
+arguments added later (``client_secret``, ``client_id``). These helpers let the
+built-in middleware and provider pass the new arguments when the implementation
+understands them and fall back to the old call shape when it does not.
+"""
+
+import inspect
+from collections.abc import Callable
+from functools import lru_cache
+from typing import Any
+
+
+@lru_cache(maxsize=256)
+def _accepts(func: Any, name: str) -> bool:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - builtins / C callables
+        # Can't introspect it; assume the modern signature and let the call raise.
+        return True
+
+    for parameter in signature.parameters.values():
+        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.name == name and parameter.kind is not inspect.Parameter.POSITIONAL_ONLY:
+            return True
+
+    return False
+
+
+def supports_keyword(func: Callable[..., Any], name: str) -> bool:
+    """
+    Report whether ``func`` can be called with the keyword argument ``name``.
+
+    For bound methods the underlying function is inspected, so the cache never
+    keeps a provider or token store instance alive.
+    """
+    target = inspect.unwrap(getattr(func, "__func__", func))
+
+    try:
+        return bool(_accepts(target, name))
+    except TypeError:  # unhashable callable — check without caching
+        return bool(_accepts.__wrapped__(target, name))
+
+
+__all__ = ["supports_keyword"]

--- a/src/chuk_mcp_server/oauth/constants.py
+++ b/src/chuk_mcp_server/oauth/constants.py
@@ -14,6 +14,24 @@ AUTH_METHOD_CLIENT_SECRET_POST = "client_secret_post"
 AUTH_METHOD_CLIENT_SECRET_BASIC = "client_secret_basic"
 AUTH_METHOD_NONE = "none"
 
+SUPPORTED_AUTH_METHODS = (
+    AUTH_METHOD_CLIENT_SECRET_POST,
+    AUTH_METHOD_CLIENT_SECRET_BASIC,
+    AUTH_METHOD_NONE,
+)
+
+# Methods that oblige the client to authenticate at the token endpoint.
+CONFIDENTIAL_AUTH_METHODS = (
+    AUTH_METHOD_CLIENT_SECRET_POST,
+    AUTH_METHOD_CLIENT_SECRET_BASIC,
+)
+
+# Default for clients that do not declare token_endpoint_auth_method, and for
+# clients registered before the field was persisted. RFC 7591 defaults to
+# client_secret_basic, but MCP clients are overwhelmingly public + PKCE, and
+# defaulting to confidential would reject every already-registered client.
+DEFAULT_AUTH_METHOD = AUTH_METHOD_NONE
+
 
 # ---------------------------------------------------------------------------
 # Code challenge methods
@@ -44,12 +62,46 @@ PATH_CALLBACK = "/oauth/callback"
 # ---------------------------------------------------------------------------
 PARAM_GRANT_TYPE = "grant_type"
 PARAM_CLIENT_ID = "client_id"
+PARAM_CLIENT_SECRET = "client_secret"
+PARAM_TOKEN_ENDPOINT_AUTH_METHOD = "token_endpoint_auth_method"
 PARAM_REDIRECT_URI = "redirect_uri"
 PARAM_CODE_VERIFIER = "code_verifier"
+PARAM_CODE_CHALLENGE = "code_challenge"
+PARAM_CODE_CHALLENGE_METHOD = "code_challenge_method"
 PARAM_REFRESH_TOKEN = "refresh_token"
 PARAM_CODE = "code"
 PARAM_STATE = "state"
+PARAM_SCOPE = "scope"
 PARAM_RESPONSE_TYPE = "response_type"
+PARAM_CLIENT_NAME = "client_name"
+PARAM_REDIRECT_URIS = "redirect_uris"
+PARAM_ERROR = "error"
+PARAM_ERROR_DESCRIPTION = "error_description"
+
+# Token response fields
+PARAM_ACCESS_TOKEN = "access_token"
+PARAM_TOKEN_TYPE = "token_type"
+PARAM_EXPIRES_IN = "expires_in"
+
+
+# ---------------------------------------------------------------------------
+# HTTP client authentication (RFC 6749 section 2.3.1)
+# ---------------------------------------------------------------------------
+HEADER_AUTHORIZATION = "authorization"
+HEADER_WWW_AUTHENTICATE = "WWW-Authenticate"
+AUTH_SCHEME_BASIC = "basic"
+BASIC_AUTH_REALM = 'Basic realm="oauth"'
+BASIC_CREDENTIALS_SEPARATOR = ":"
+
+
+# ---------------------------------------------------------------------------
+# HTTP status codes used by the OAuth endpoints
+# ---------------------------------------------------------------------------
+HTTP_OK = 200
+HTTP_CREATED = 201
+HTTP_BAD_REQUEST = 400
+HTTP_UNAUTHORIZED = 401
+HTTP_INTERNAL_SERVER_ERROR = 500
 
 
 # ---------------------------------------------------------------------------

--- a/src/chuk_mcp_server/oauth/constants.py
+++ b/src/chuk_mcp_server/oauth/constants.py
@@ -95,6 +95,26 @@ BASIC_CREDENTIALS_SEPARATOR = ":"
 
 
 # ---------------------------------------------------------------------------
+# Redirect URI handling
+# ---------------------------------------------------------------------------
+QUERY_START = "?"
+QUERY_SEPARATOR = "&"
+
+# Schemes a browser executes rather than navigates to. A client must not be able
+# to register one, because the callback page renders the redirect URI as a link.
+DANGEROUS_URI_SCHEMES = frozenset(
+    {
+        "javascript",
+        "data",
+        "vbscript",
+        "file",
+        "blob",
+        "about",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
 # HTTP status codes used by the OAuth endpoints
 # ---------------------------------------------------------------------------
 HTTP_OK = 200

--- a/src/chuk_mcp_server/oauth/crypto.py
+++ b/src/chuk_mcp_server/oauth/crypto.py
@@ -1,0 +1,29 @@
+"""
+Constant-time comparison for OAuth credential material.
+
+``secrets.compare_digest`` raises ``TypeError`` when handed a ``str`` containing
+non-ASCII characters, and every credential this server compares (client secrets,
+PKCE verifiers and challenges) arrives from the network. Comparing the UTF-8
+encodings instead keeps the comparison constant-time while accepting any input.
+"""
+
+import secrets
+
+__all__ = ["secure_compare"]
+
+
+def secure_compare(expected: str | None, presented: str | None) -> bool:
+    """
+    Compare two credential strings in constant time.
+
+    Args:
+        expected: The stored value
+        presented: The value supplied by the caller
+
+    Returns:
+        True if both are present and equal
+    """
+    if expected is None or presented is None:
+        return False
+
+    return secrets.compare_digest(expected.encode("utf-8"), presented.encode("utf-8"))

--- a/src/chuk_mcp_server/oauth/middleware.py
+++ b/src/chuk_mcp_server/oauth/middleware.py
@@ -21,26 +21,49 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from .base_provider import BaseOAuthProvider
+from .client_auth import CredentialError, extract_client_credentials
+from .compat import supports_keyword
 from .constants import (
     AUTH_METHOD_CLIENT_SECRET_BASIC,
     AUTH_METHOD_CLIENT_SECRET_POST,
     AUTH_METHOD_NONE,
+    BASIC_AUTH_REALM,
     CODE_CHALLENGE_PLAIN,
     CODE_CHALLENGE_S256,
+    DEFAULT_AUTH_METHOD,
+    ERROR_INVALID_CLIENT,
     ERROR_INVALID_CLIENT_METADATA,
     ERROR_INVALID_REQUEST,
     ERROR_SERVER_ERROR,
     ERROR_UNSUPPORTED_GRANT_TYPE,
     GRANT_AUTHORIZATION_CODE,
     GRANT_REFRESH_TOKEN,
+    HEADER_AUTHORIZATION,
+    HEADER_WWW_AUTHENTICATE,
+    HTTP_BAD_REQUEST,
+    HTTP_CREATED,
+    HTTP_INTERNAL_SERVER_ERROR,
+    HTTP_UNAUTHORIZED,
+    PARAM_ACCESS_TOKEN,
     PARAM_CLIENT_ID,
+    PARAM_CLIENT_NAME,
+    PARAM_CLIENT_SECRET,
     PARAM_CODE,
+    PARAM_CODE_CHALLENGE,
+    PARAM_CODE_CHALLENGE_METHOD,
     PARAM_CODE_VERIFIER,
+    PARAM_ERROR,
+    PARAM_ERROR_DESCRIPTION,
+    PARAM_EXPIRES_IN,
     PARAM_GRANT_TYPE,
     PARAM_REDIRECT_URI,
+    PARAM_REDIRECT_URIS,
     PARAM_REFRESH_TOKEN,
     PARAM_RESPONSE_TYPE,
+    PARAM_SCOPE,
     PARAM_STATE,
+    PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
+    PARAM_TOKEN_TYPE,
     PATH_AUTHORIZATION_SERVER_METADATA,
     PATH_AUTHORIZE,
     PATH_PROTECTED_RESOURCE,
@@ -48,7 +71,7 @@ from .constants import (
     PATH_TOKEN,
     RESPONSE_TYPE_CODE,
 )
-from .models import AuthorizationParams
+from .models import AuthorizationParams, RegistrationError, TokenError
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +212,32 @@ class OAuthMiddleware:
 
         return JSONResponse(metadata, headers={"Access-Control-Allow-Origin": "*"})
 
+    @staticmethod
+    def _resolve_code_challenge_method(
+        code_challenge: str | None,
+        requested_method: str | None,
+    ) -> Literal["S256", "plain"] | None:
+        """
+        Decide which PKCE method to record against an authorization code.
+
+        RFC 7636 section 4.3: when a challenge is present but no method is named,
+        the method is "plain". Recording None instead would leave the challenge
+        unverifiable at the token endpoint, so a challenge always gets a method.
+
+        Raises:
+            ValueError: If an unrecognised method is requested
+        """
+        if requested_method in (CODE_CHALLENGE_S256, CODE_CHALLENGE_PLAIN):
+            return cast(Literal["S256", "plain"], requested_method)
+
+        if requested_method:
+            raise ValueError(f"Unsupported code_challenge_method: {requested_method}")
+
+        if not code_challenge:
+            return None
+
+        return cast(Literal["S256", "plain"], CODE_CHALLENGE_PLAIN)
+
     async def _authorize_endpoint(self, request: Request) -> Any:
         """
         OAuth authorization endpoint.
@@ -196,23 +245,24 @@ class OAuthMiddleware:
         Handles authorization requests from MCP clients.
         May redirect to external provider for authentication.
         """
+        params: dict[str, str] = {}
         try:
             # Parse authorization parameters
             params = dict(request.query_params)
 
-            # Create AuthorizationParams object
-            code_challenge_method_value = params.get("code_challenge_method")
-            code_challenge_method: Literal["S256", "plain"] | None = None
-            if code_challenge_method_value in (CODE_CHALLENGE_S256, CODE_CHALLENGE_PLAIN):
-                code_challenge_method = cast(Literal["S256", "plain"], code_challenge_method_value)
+            code_challenge = params.get(PARAM_CODE_CHALLENGE)
+            code_challenge_method = self._resolve_code_challenge_method(
+                code_challenge,
+                params.get(PARAM_CODE_CHALLENGE_METHOD),
+            )
 
             auth_params = AuthorizationParams(
                 response_type=params.get(PARAM_RESPONSE_TYPE, RESPONSE_TYPE_CODE),
                 client_id=params[PARAM_CLIENT_ID],
                 redirect_uri=params[PARAM_REDIRECT_URI],
-                scope=params.get("scope"),
+                scope=params.get(PARAM_SCOPE),
                 state=params.get(PARAM_STATE),
-                code_challenge=params.get("code_challenge"),
+                code_challenge=code_challenge,
                 code_challenge_method=code_challenge_method,
             )
 
@@ -240,8 +290,8 @@ class OAuthMiddleware:
                 redirect_uri = params.get(PARAM_REDIRECT_URI)
                 if redirect_uri:
                     error_params = {
-                        "error": ERROR_SERVER_ERROR,
-                        "error_description": "Authorization failed",
+                        PARAM_ERROR: ERROR_SERVER_ERROR,
+                        PARAM_ERROR_DESCRIPTION: "Authorization failed",
                     }
                     if params.get(PARAM_STATE):
                         error_params[PARAM_STATE] = params[PARAM_STATE]
@@ -262,7 +312,7 @@ class OAuthMiddleware:
                     </body>
                 </html>
                 """,
-                status_code=400,
+                status_code=HTTP_BAD_REQUEST,
             )
 
     async def _token_endpoint(self, request: Request) -> JSONResponse:
@@ -290,20 +340,37 @@ class OAuthMiddleware:
             logger.debug(f"🔐 Token exchange - redirect_uri: {get_form_str(PARAM_REDIRECT_URI)}")
             logger.debug(f"🔐 Token exchange - code_verifier present: {bool(get_form_str(PARAM_CODE_VERIFIER))}")
 
+            # Client credentials may arrive in the body (client_secret_post) or in
+            # an Authorization: Basic header (client_secret_basic) — RFC 6749 2.3.1.
+            credentials = extract_client_credentials(
+                request.headers.get(HEADER_AUTHORIZATION),
+                get_form_str(PARAM_CLIENT_ID),
+                get_form_str(PARAM_CLIENT_SECRET),
+            )
+            if not credentials.is_valid:
+                return self._credential_error_response(credentials.error)
+
+            client_id = credentials.client_id
+            client_secret = credentials.client_secret
+
             if grant_type == GRANT_AUTHORIZATION_CODE:
                 # Exchange authorization code for token
                 code = get_form_str(PARAM_CODE)
-                client_id = get_form_str(PARAM_CLIENT_ID)
                 redirect_uri = get_form_str(PARAM_REDIRECT_URI)
                 code_verifier = get_form_str(PARAM_CODE_VERIFIER)
 
                 if not code or not client_id or not redirect_uri:
                     return JSONResponse(
-                        {"error": ERROR_INVALID_REQUEST, "error_description": "Missing required parameters"},
-                        status_code=400,
+                        {
+                            PARAM_ERROR: ERROR_INVALID_REQUEST,
+                            PARAM_ERROR_DESCRIPTION: "Missing required parameters",
+                        },
+                        status_code=HTTP_BAD_REQUEST,
                     )
 
-                token = await self.provider.exchange_authorization_code(
+                token = await self._call_provider(
+                    self.provider.exchange_authorization_code,
+                    client_secret,
                     code=code,
                     client_id=client_id,
                     redirect_uri=redirect_uri,
@@ -312,16 +379,20 @@ class OAuthMiddleware:
             elif grant_type == GRANT_REFRESH_TOKEN:
                 # Refresh access token
                 refresh_token = get_form_str(PARAM_REFRESH_TOKEN)
-                client_id = get_form_str(PARAM_CLIENT_ID)
-                scope = get_form_str("scope")
+                scope = get_form_str(PARAM_SCOPE)
 
                 if not refresh_token or not client_id:
                     return JSONResponse(
-                        {"error": ERROR_INVALID_REQUEST, "error_description": "Missing required parameters"},
-                        status_code=400,
+                        {
+                            PARAM_ERROR: ERROR_INVALID_REQUEST,
+                            PARAM_ERROR_DESCRIPTION: "Missing required parameters",
+                        },
+                        status_code=HTTP_BAD_REQUEST,
                     )
 
-                token = await self.provider.exchange_refresh_token(
+                token = await self._call_provider(
+                    self.provider.exchange_refresh_token,
+                    client_secret,
                     refresh_token=refresh_token,
                     client_id=client_id,
                     scope=scope,
@@ -329,32 +400,107 @@ class OAuthMiddleware:
             else:
                 return JSONResponse(
                     {
-                        "error": ERROR_UNSUPPORTED_GRANT_TYPE,
-                        "error_description": f"Grant type {grant_type} not supported",
+                        PARAM_ERROR: ERROR_UNSUPPORTED_GRANT_TYPE,
+                        PARAM_ERROR_DESCRIPTION: f"Grant type {grant_type} not supported",
                     },
-                    status_code=400,
+                    status_code=HTTP_BAD_REQUEST,
                 )
 
             # Return token response
             return JSONResponse(
                 {
-                    "access_token": str(token.access_token),
-                    "token_type": token.token_type,
-                    "expires_in": token.expires_in,
-                    "refresh_token": str(token.refresh_token) if token.refresh_token else None,
-                    "scope": token.scope,
+                    PARAM_ACCESS_TOKEN: str(token.access_token),
+                    PARAM_TOKEN_TYPE: token.token_type,
+                    PARAM_EXPIRES_IN: token.expires_in,
+                    PARAM_REFRESH_TOKEN: str(token.refresh_token) if token.refresh_token else None,
+                    PARAM_SCOPE: token.scope,
                 }
+            )
+
+        except TokenError as e:
+            logger.warning(f"Token exchange rejected: {e.error}")
+            if e.error == ERROR_INVALID_CLIENT:
+                return self._invalid_client_response("Client authentication failed")
+            return JSONResponse(
+                {
+                    PARAM_ERROR: e.error,
+                    PARAM_ERROR_DESCRIPTION: "Token exchange failed",
+                },
+                status_code=HTTP_BAD_REQUEST,
             )
 
         except Exception as e:
             logger.error(f"Token exchange failed: {type(e).__name__}", exc_info=True)
             return JSONResponse(
                 {
-                    "error": ERROR_INVALID_REQUEST,
-                    "error_description": "Token exchange failed",
+                    PARAM_ERROR: ERROR_INVALID_REQUEST,
+                    PARAM_ERROR_DESCRIPTION: "Token exchange failed",
                 },
-                status_code=400,
+                status_code=HTTP_BAD_REQUEST,
             )
+
+    @staticmethod
+    def _invalid_client_response(description: str) -> JSONResponse:
+        """Build an RFC 6749 section 5.2 invalid_client response."""
+        return JSONResponse(
+            {PARAM_ERROR: ERROR_INVALID_CLIENT, PARAM_ERROR_DESCRIPTION: description},
+            status_code=HTTP_UNAUTHORIZED,
+            headers={HEADER_WWW_AUTHENTICATE: BASIC_AUTH_REALM},
+        )
+
+    @classmethod
+    def _credential_error_response(cls, error: CredentialError | None) -> JSONResponse:
+        """Map a credential extraction failure onto an OAuth error response."""
+        if error is CredentialError.CLIENT_ID_MISMATCH:
+            # Not an authentication failure — the request contradicts itself.
+            return JSONResponse(
+                {
+                    PARAM_ERROR: ERROR_INVALID_REQUEST,
+                    PARAM_ERROR_DESCRIPTION: "client_id mismatch between Authorization header and request body",
+                },
+                status_code=HTTP_BAD_REQUEST,
+            )
+
+        descriptions = {
+            CredentialError.MALFORMED_HEADER: "Malformed Authorization header",
+            CredentialError.CLIENT_SECRET_MISMATCH: "Conflicting client credentials",
+        }
+        description = descriptions.get(error) if error else None
+        return cls._invalid_client_response(description or "Client authentication failed")
+
+    @staticmethod
+    async def _call_provider(
+        method: Any,
+        client_secret: str | None,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Invoke a provider token method, passing client_secret when it is accepted.
+
+        Providers written against an earlier release do not declare client_secret.
+        Those cannot authenticate their clients, so a secret sent to one is refused
+        rather than silently ignored.
+        """
+        if supports_keyword(method, PARAM_CLIENT_SECRET):
+            return await method(client_secret=client_secret, **kwargs)
+
+        if client_secret is not None:
+            logger.error(
+                "Provider %s cannot verify client_secret; rejecting the request rather "
+                "than ignoring the credential. Add a client_secret parameter to it.",
+                getattr(method, "__qualname__", method),
+            )
+            raise TokenError(
+                error=ERROR_INVALID_CLIENT,
+                error_description="Client authentication is not supported by this provider",
+            )
+
+        logger.warning(
+            "Provider %s does not accept client_secret; confidential clients cannot be "
+            "authenticated at the token endpoint.",
+            getattr(method, "__qualname__", method),
+        )
+        return await method(**kwargs)
 
     async def _register_endpoint(self, request: Request) -> JSONResponse:
         """
@@ -371,22 +517,37 @@ class OAuthMiddleware:
 
             return JSONResponse(
                 {
-                    "client_id": client_info.client_id,
-                    "client_secret": client_info.client_secret,
-                    "client_name": client_info.client_name,
-                    "redirect_uris": client_info.redirect_uris,
+                    PARAM_CLIENT_ID: client_info.client_id,
+                    PARAM_CLIENT_SECRET: client_info.client_secret,
+                    PARAM_CLIENT_NAME: client_info.client_name,
+                    PARAM_REDIRECT_URIS: client_info.redirect_uris,
+                    # Echo back what was actually recorded, so a client can tell
+                    # whether its requested method was honoured (RFC 7591 3.2.1).
+                    PARAM_TOKEN_ENDPOINT_AUTH_METHOD: getattr(
+                        client_info, PARAM_TOKEN_ENDPOINT_AUTH_METHOD, DEFAULT_AUTH_METHOD
+                    ),
                 },
-                status_code=201,
+                status_code=HTTP_CREATED,
+            )
+
+        except RegistrationError as e:
+            logger.warning(f"Client registration rejected: {e.error}")
+            return JSONResponse(
+                {
+                    PARAM_ERROR: e.error,
+                    PARAM_ERROR_DESCRIPTION: e.error_description or "Client registration failed",
+                },
+                status_code=HTTP_BAD_REQUEST,
             )
 
         except Exception as e:
             logger.error(f"Client registration failed: {type(e).__name__}", exc_info=True)
             return JSONResponse(
                 {
-                    "error": ERROR_INVALID_CLIENT_METADATA,
-                    "error_description": "Client registration failed",
+                    PARAM_ERROR: ERROR_INVALID_CLIENT_METADATA,
+                    PARAM_ERROR_DESCRIPTION: "Client registration failed",
                 },
-                status_code=400,
+                status_code=HTTP_BAD_REQUEST,
             )
 
     async def _external_callback_endpoint(self, request: Request) -> Any:
@@ -400,7 +561,7 @@ class OAuthMiddleware:
             # Get authorization code and state
             code = request.query_params.get("code")
             state = request.query_params.get("state")
-            error = request.query_params.get("error")
+            error = request.query_params.get(PARAM_ERROR)
 
             if error:
                 # External authorization failed
@@ -415,7 +576,7 @@ class OAuthMiddleware:
                         </body>
                     </html>
                     """,
-                    status_code=400,
+                    status_code=HTTP_BAD_REQUEST,
                 )
 
             if not code or not state:
@@ -429,7 +590,7 @@ class OAuthMiddleware:
                         </body>
                     </html>
                     """,
-                    status_code=400,
+                    status_code=HTTP_BAD_REQUEST,
                 )
 
             # Handle external provider callback
@@ -482,5 +643,5 @@ class OAuthMiddleware:
                     </body>
                 </html>
                 """,
-                status_code=500,
+                status_code=HTTP_INTERNAL_SERVER_ERROR,
             )

--- a/src/chuk_mcp_server/oauth/middleware.py
+++ b/src/chuk_mcp_server/oauth/middleware.py
@@ -15,7 +15,6 @@ Works with any OAuth provider that implements BaseOAuthProvider.
 import html
 import logging
 from typing import Any, Literal, cast
-from urllib.parse import urlencode
 
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -72,6 +71,7 @@ from .constants import (
     RESPONSE_TYPE_CODE,
 )
 from .models import AuthorizationParams, RegistrationError, TokenError
+from .redirect_uri import build_redirect_url, is_safe_redirect_uri
 
 logger = logging.getLogger(__name__)
 
@@ -281,14 +281,17 @@ class OAuthMiddleware:
             if result.get(PARAM_STATE):
                 redirect_params[PARAM_STATE] = result[PARAM_STATE]
 
-            redirect_url = f"{auth_params.redirect_uri}?{urlencode(redirect_params)}"
-            return RedirectResponse(redirect_url)
+            return RedirectResponse(build_redirect_url(auth_params.redirect_uri, redirect_params))
 
         except Exception:
-            # Attempt to redirect with error, but only if redirect_uri is available
+            # Redirect the error back to the client, but ONLY once the redirect URI
+            # is confirmed to be registered for this client. RFC 6749 4.1.2.1: an
+            # unvalidated redirect URI must never be automatically navigated to.
             try:
+                client_id = params.get(PARAM_CLIENT_ID)
                 redirect_uri = params.get(PARAM_REDIRECT_URI)
-                if redirect_uri:
+
+                if client_id and redirect_uri and await self.provider.validate_redirect_uri(client_id, redirect_uri):
                     error_params = {
                         PARAM_ERROR: ERROR_SERVER_ERROR,
                         PARAM_ERROR_DESCRIPTION: "Authorization failed",
@@ -296,8 +299,9 @@ class OAuthMiddleware:
                     if params.get(PARAM_STATE):
                         error_params[PARAM_STATE] = params[PARAM_STATE]
 
-                    error_url = f"{redirect_uri}?{urlencode(error_params)}"
-                    return RedirectResponse(error_url)
+                    return RedirectResponse(build_redirect_url(redirect_uri, error_params))
+
+                logger.warning("Refusing to redirect an authorization error to an unregistered redirect_uri")
             except Exception:
                 logger.debug("Failed to redirect with error response", exc_info=True)
 
@@ -335,8 +339,7 @@ class OAuthMiddleware:
 
             logger.debug(f"🔐 Token exchange request - grant_type: {grant_type}")
             logger.debug(f"🔐 Token exchange - client_id: {get_form_str(PARAM_CLIENT_ID)}")
-            code_val = get_form_str(PARAM_CODE)
-            logger.debug(f"🔐 Token exchange - code: {code_val[:20]}..." if code_val else "no code")
+            logger.debug(f"🔐 Token exchange - code present: {bool(get_form_str(PARAM_CODE))}")
             logger.debug(f"🔐 Token exchange - redirect_uri: {get_form_str(PARAM_REDIRECT_URI)}")
             logger.debug(f"🔐 Token exchange - code_verifier present: {bool(get_form_str(PARAM_CODE_VERIFIER))}")
 
@@ -609,7 +612,13 @@ class OAuthMiddleware:
             if result.get(PARAM_STATE):
                 redirect_params[PARAM_STATE] = result[PARAM_STATE]
 
-            redirect_url = f"{result['redirect_uri']}?{urlencode(redirect_params)}"
+            redirect_url = build_redirect_url(result["redirect_uri"], redirect_params)
+
+            # The URI came from a registered client, but the callback page turns it
+            # into a link — so re-check the scheme before rendering it as one.
+            if not is_safe_redirect_uri(redirect_url):
+                logger.error("Refusing to render a callback link for an unsafe redirect_uri")
+                raise ValueError("Unsafe redirect URI")
 
             # Return success page with auto-redirect
             escaped_redirect = html.escape(redirect_url)

--- a/src/chuk_mcp_server/oauth/models.py
+++ b/src/chuk_mcp_server/oauth/models.py
@@ -7,6 +7,8 @@ Pure Python OAuth models without mcp library dependencies.
 from dataclasses import dataclass
 from typing import Literal
 
+from .constants import DEFAULT_AUTH_METHOD
+
 
 @dataclass
 class AuthorizationParams:
@@ -40,6 +42,7 @@ class OAuthClientInfo:
     client_secret: str
     client_name: str
     redirect_uris: list[str]
+    token_endpoint_auth_method: str = DEFAULT_AUTH_METHOD
 
 
 class OAuthError(Exception):

--- a/src/chuk_mcp_server/oauth/providers/google_drive.py
+++ b/src/chuk_mcp_server/oauth/providers/google_drive.py
@@ -48,6 +48,7 @@ from ..models import (
     RegistrationError,
     TokenError,
 )
+from ..redirect_uri import is_safe_redirect_uri
 from ..token_store import TokenStore
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,16 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             "requires_external_authorization": True,
         }
 
+    def _access_token_lifetime(self) -> int:
+        """How long an issued access token actually lives, in seconds.
+
+        Reported to the client as expires_in, so it must match the TTL the token
+        store applies — otherwise clients cache a token past its expiry and see
+        spurious 401s.
+        """
+        lifetime = getattr(self.token_store, "access_token_ttl", None)
+        return int(lifetime) if lifetime else DEFAULT_TOKEN_EXPIRY
+
     async def _authenticate_client(self, client_id: str, client_secret: str | None) -> None:
         """Authenticate a client at the token endpoint.
 
@@ -352,7 +363,7 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             OAuth token with access_token and refresh_token
         """
         logger.info("🔄 Exchanging authorization code for access token")
-        logger.debug(f"Authorization code (redacted): {code[:8]}...")
+        logger.debug("Authorization code received (value not logged)")
 
         # Authenticate the client before honouring the code (RFC 6749 3.2.1)
         await self._authenticate_client(client_id, client_secret)
@@ -382,12 +393,13 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             scope=code_data["scope"],
         )
 
-        logger.info(f"✓ Created access token successfully (expires in {DEFAULT_TOKEN_EXPIRY}s)")
+        expires_in = self._access_token_lifetime()
+        logger.info(f"✓ Created access token successfully (expires in {expires_in}s)")
 
         return OAuthToken(
             access_token=access_token,
             token_type="Bearer",
-            expires_in=DEFAULT_TOKEN_EXPIRY,
+            expires_in=expires_in,
             refresh_token=refresh_token,
             scope=code_data["scope"],
         )
@@ -438,7 +450,7 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
         return OAuthToken(
             access_token=new_access_token,
             token_type="Bearer",
-            expires_in=DEFAULT_TOKEN_EXPIRY,
+            expires_in=self._access_token_lifetime(),
             refresh_token=new_refresh_token,
             scope=scope,
         )
@@ -458,7 +470,7 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             Token data with user_id and Google Drive token
         """
         logger.info("🔍 Validating access token")
-        logger.debug(f"Access token (redacted): {token[:8]}...")
+        logger.debug("Access token received (value not logged)")
 
         # Validate MCP token
         token_data = await self.token_store.validate_access_token(token)
@@ -536,6 +548,15 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
                 error=ERROR_INVALID_REDIRECT_URI,
                 error_description="At least one redirect URI required",
             )
+
+        # Registration is open, so a client could otherwise register a
+        # javascript: or data: URI that the callback page later renders as a link.
+        for uri in redirect_uris:
+            if not isinstance(uri, str) or not is_safe_redirect_uri(uri):
+                raise RegistrationError(
+                    error=ERROR_INVALID_REDIRECT_URI,
+                    error_description="Redirect URIs must be absolute URIs with a navigable scheme",
+                )
 
         # RFC 7591: honour the client's declared token endpoint auth method rather
         # than discarding it. Undeclared clients register as public.

--- a/src/chuk_mcp_server/oauth/providers/google_drive.py
+++ b/src/chuk_mcp_server/oauth/providers/google_drive.py
@@ -19,10 +19,14 @@ from typing import Any
 import httpx
 
 from ..base_provider import BaseOAuthProvider
+from ..compat import supports_keyword
 from ..constants import (
+    CONFIDENTIAL_AUTH_METHODS,
+    DEFAULT_AUTH_METHOD,
     DEFAULT_TOKEN_EXPIRY,
     ERROR_INSUFFICIENT_SCOPE,
     ERROR_INVALID_CLIENT,
+    ERROR_INVALID_CLIENT_METADATA,
     ERROR_INVALID_GRANT,
     ERROR_INVALID_REDIRECT_URI,
     ERROR_INVALID_TOKEN,
@@ -31,8 +35,10 @@ from ..constants import (
     GOOGLE_USERINFO_URL,
     GRANT_AUTHORIZATION_CODE,
     GRANT_REFRESH_TOKEN,
+    PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
     PROVIDER_GOOGLE_DRIVE,
     RESPONSE_TYPE_CODE,
+    SUPPORTED_AUTH_METHODS,
 )
 from ..models import (
     AuthorizationParams,
@@ -302,12 +308,35 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             "requires_external_authorization": True,
         }
 
+    async def _authenticate_client(self, client_id: str, client_secret: str | None) -> None:
+        """Authenticate a client at the token endpoint.
+
+        Clients that registered with a confidential token_endpoint_auth_method must
+        present their secret; public clients may omit it, but a wrong secret is
+        always rejected.
+
+        Raises:
+            TokenError: If the client cannot be authenticated
+        """
+        authenticate = getattr(self.token_store, "authenticate_client", None)
+        if authenticate is None:
+            # Token store predates authenticate_client; fall back to the check it does have.
+            authenticate = self.token_store.validate_client
+
+        if not await authenticate(client_id, client_secret=client_secret):
+            logger.warning("❌ Client authentication failed at token endpoint")
+            raise TokenError(
+                error=ERROR_INVALID_CLIENT,
+                error_description="Client authentication failed",
+            )
+
     async def exchange_authorization_code(
         self,
         code: str,
         client_id: str,
         redirect_uri: str,
         code_verifier: str | None = None,
+        client_secret: str | None = None,
     ) -> OAuthToken:
         """Exchange authorization code for access token.
 
@@ -316,12 +345,17 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             client_id: MCP client ID
             redirect_uri: Redirect URI (must match)
             code_verifier: PKCE code verifier
+            client_secret: Client secret, required for clients that registered
+                with a confidential token_endpoint_auth_method
 
         Returns:
             OAuth token with access_token and refresh_token
         """
         logger.info("🔄 Exchanging authorization code for access token")
         logger.debug(f"Authorization code (redacted): {code[:8]}...")
+
+        # Authenticate the client before honouring the code (RFC 6749 3.2.1)
+        await self._authenticate_client(client_id, client_secret)
 
         # Validate authorization code
         code_data = await self.token_store.validate_authorization_code(
@@ -363,6 +397,7 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
         refresh_token: str,
         client_id: str,
         scope: str | None = None,
+        client_secret: str | None = None,
     ) -> OAuthToken:
         """Refresh access token using refresh token.
 
@@ -370,11 +405,27 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
             refresh_token: Refresh token
             client_id: MCP client ID
             scope: Optional scope (must be subset of original)
+            client_secret: Client secret, required for clients that registered
+                with a confidential token_endpoint_auth_method
 
         Returns:
             New OAuth token
         """
-        result = await self.token_store.refresh_access_token(refresh_token)
+        # Authenticate the client before honouring the token (RFC 6749 section 6)
+        await self._authenticate_client(client_id, client_secret)
+
+        # Bind the refresh token to the client it was issued to. Passed only when
+        # the token store understands it, so custom stores keep working.
+        refresh = self.token_store.refresh_access_token
+        if supports_keyword(refresh, "client_id"):
+            result = await refresh(refresh_token, client_id=client_id)
+        else:
+            logger.warning(
+                "Token store %s does not support client-bound refresh; a leaked refresh "
+                "token could be redeemed by another client. Update it to accept client_id.",
+                type(self.token_store).__name__,
+            )
+            result = await refresh(refresh_token)
 
         if not result:
             raise TokenError(
@@ -486,16 +537,44 @@ class GoogleDriveOAuthProvider(BaseOAuthProvider):
                 error_description="At least one redirect URI required",
             )
 
-        credentials = await self.token_store.register_client(
-            client_name=client_name,
-            redirect_uris=redirect_uris,
-        )
+        # RFC 7591: honour the client's declared token endpoint auth method rather
+        # than discarding it. Undeclared clients register as public.
+        auth_method = client_metadata.get(PARAM_TOKEN_ENDPOINT_AUTH_METHOD) or DEFAULT_AUTH_METHOD
+        if auth_method not in SUPPORTED_AUTH_METHODS:
+            raise RegistrationError(
+                error=ERROR_INVALID_CLIENT_METADATA,
+                error_description=(
+                    f"Unsupported token_endpoint_auth_method. Supported: {', '.join(SUPPORTED_AUTH_METHODS)}"
+                ),
+            )
+
+        register = self.token_store.register_client
+        if supports_keyword(register, PARAM_TOKEN_ENDPOINT_AUTH_METHOD):
+            credentials = await register(
+                client_name=client_name,
+                redirect_uris=redirect_uris,
+                token_endpoint_auth_method=auth_method,
+            )
+        else:
+            if auth_method in CONFIDENTIAL_AUTH_METHODS:
+                raise RegistrationError(
+                    error=ERROR_INVALID_CLIENT_METADATA,
+                    error_description=(
+                        "This server's token store cannot register confidential clients; "
+                        "register as a public client and use PKCE"
+                    ),
+                )
+            credentials = await register(
+                client_name=client_name,
+                redirect_uris=redirect_uris,
+            )
 
         return OAuthClientInfo(
             client_id=credentials["client_id"],
             client_secret=credentials["client_secret"],
             client_name=client_name,
             redirect_uris=redirect_uris,
+            token_endpoint_auth_method=credentials.get(PARAM_TOKEN_ENDPOINT_AUTH_METHOD, auth_method),
         )
 
     # ============================================================================

--- a/src/chuk_mcp_server/oauth/redirect_uri.py
+++ b/src/chuk_mcp_server/oauth/redirect_uri.py
@@ -1,0 +1,71 @@
+"""
+Redirect URI validation and construction.
+
+The redirect URI is the one piece of client-supplied data the authorization
+endpoint hands straight back to a browser, so it gets two checks:
+
+- at registration, the scheme must be one a browser will navigate to safely —
+  ``javascript:`` and ``data:`` URIs registered here would later be rendered as
+  links on the callback page (RFC 9700 section 4.1)
+- at redirect time, parameters must be appended to whatever query string the
+  registered URI already carries, rather than blindly appended after a ``?``
+"""
+
+from urllib.parse import urlencode, urlparse
+
+from .constants import DANGEROUS_URI_SCHEMES, QUERY_SEPARATOR, QUERY_START
+
+__all__ = ["build_redirect_url", "is_safe_redirect_uri"]
+
+
+def is_safe_redirect_uri(redirect_uri: str) -> bool:
+    """
+    Report whether a redirect URI is safe to register and later navigate to.
+
+    Rejects schemes that execute in the browser rather than navigating, and
+    relative URIs (RFC 6749 section 3.1.2 requires an absolute URI).
+
+    Args:
+        redirect_uri: The URI a client wants to register
+
+    Returns:
+        True if the URI is absolute and uses a navigable scheme
+    """
+    if not redirect_uri or not redirect_uri.strip():
+        return False
+
+    try:
+        parsed = urlparse(redirect_uri)
+    except ValueError:
+        return False
+
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        # Relative URI — not an absolute redirect target.
+        return False
+
+    if scheme in DANGEROUS_URI_SCHEMES:
+        return False
+
+    # An absolute URI needs somewhere to go: either a network location
+    # (https://app.example/cb) or an opaque path for native app schemes
+    # (com.example.app:/callback).
+    return bool(parsed.netloc or parsed.path)
+
+
+def build_redirect_url(redirect_uri: str, params: dict[str, str]) -> str:
+    """
+    Append query parameters to a redirect URI, preserving any it already has.
+
+    Args:
+        redirect_uri: The client's registered redirect URI
+        params: Parameters to append
+
+    Returns:
+        The URI to redirect to
+    """
+    if not params:
+        return redirect_uri
+
+    separator = QUERY_SEPARATOR if QUERY_START in redirect_uri else QUERY_START
+    return f"{redirect_uri}{separator}{urlencode(params)}"

--- a/src/chuk_mcp_server/oauth/token_models.py
+++ b/src/chuk_mcp_server/oauth/token_models.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import orjson
 
+from .constants import DEFAULT_AUTH_METHOD, SUPPORTED_AUTH_METHODS
+
 # ============================================================================
 # Authorization Code Data
 # ============================================================================
@@ -221,6 +223,7 @@ class ClientData:
     client_name: str
     client_secret: str
     redirect_uris: list[str]
+    token_endpoint_auth_method: str = DEFAULT_AUTH_METHOD
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
 
     def __post_init__(self) -> None:
@@ -228,6 +231,13 @@ class ClientData:
         # Validate client_name is not empty
         if not self.client_name or not self.client_name.strip():
             raise ValueError("client_name must not be empty")
+
+        # Validate the declared token endpoint auth method
+        if self.token_endpoint_auth_method not in SUPPORTED_AUTH_METHODS:
+            raise ValueError(
+                f"token_endpoint_auth_method must be one of {SUPPORTED_AUTH_METHODS}, "
+                f"got {self.token_endpoint_auth_method!r}"
+            )
 
         # Validate redirect_uris
         if not self.redirect_uris:
@@ -243,6 +253,7 @@ class ClientData:
             "client_name": self.client_name,
             "client_secret": self.client_secret,
             "redirect_uris": self.redirect_uris,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
             "created_at": self.created_at,
         }
 
@@ -258,6 +269,8 @@ class ClientData:
             client_name=data["client_name"],
             client_secret=data["client_secret"],
             redirect_uris=data["redirect_uris"],
+            # Clients registered before this field existed are treated as public.
+            token_endpoint_auth_method=data.get("token_endpoint_auth_method", DEFAULT_AUTH_METHOD),
             created_at=data.get("created_at", datetime.now().isoformat()),
         )
 

--- a/src/chuk_mcp_server/oauth/token_store.py
+++ b/src/chuk_mcp_server/oauth/token_store.py
@@ -54,6 +54,7 @@ from .constants import (
     TTL_PENDING_AUTH,
     TTL_REFRESH_TOKEN,
 )
+from .crypto import secure_compare
 from .token_models import (
     AccessTokenData,
     AuthorizationCodeData,
@@ -192,10 +193,10 @@ class TokenStore(BaseTokenStore):
 
                     verifier_hash = hashlib.sha256(code_verifier.encode()).digest()
                     verifier_challenge = base64.urlsafe_b64encode(verifier_hash).decode().rstrip("=")
-                    if not secrets.compare_digest(verifier_challenge, code_data.code_challenge):
+                    if not secure_compare(code_data.code_challenge, verifier_challenge):
                         return None
                 elif challenge_method == CODE_CHALLENGE_PLAIN:
-                    if not secrets.compare_digest(code_verifier, code_data.code_challenge):
+                    if not secure_compare(code_data.code_challenge, code_verifier):
                         return None
                 else:
                     return None
@@ -529,7 +530,7 @@ class TokenStore(BaseTokenStore):
 
         # Validate secret if provided
         if client_secret is not None:
-            if not secrets.compare_digest(client_data.client_secret, client_secret):
+            if not secure_compare(client_data.client_secret, client_secret):
                 return False
 
         # Validate redirect URI if provided
@@ -571,7 +572,7 @@ class TokenStore(BaseTokenStore):
             return False
 
         if client_secret is not None:
-            if not secrets.compare_digest(client_data.client_secret, client_secret):
+            if not secure_compare(client_data.client_secret, client_secret):
                 return False
 
         if redirect_uri is not None:

--- a/src/chuk_mcp_server/oauth/token_store.py
+++ b/src/chuk_mcp_server/oauth/token_store.py
@@ -38,6 +38,8 @@ from .base_token_store import BaseTokenStore
 from .constants import (
     CODE_CHALLENGE_PLAIN,
     CODE_CHALLENGE_S256,
+    CONFIDENTIAL_AUTH_METHODS,
+    DEFAULT_AUTH_METHOD,
     ENV_ACCESS_TOKEN_TTL,
     ENV_AUTH_CODE_TTL,
     ENV_CLIENT_REGISTRATION_TTL,
@@ -178,18 +180,25 @@ class TokenStore(BaseTokenStore):
                 if not code_verifier:
                     return None
 
+                # RFC 7636 section 4.3: an absent code_challenge_method means "plain".
+                # Never fall through without verifying — an unrecognised method must
+                # fail closed rather than silently accept any verifier.
+                challenge_method = code_data.code_challenge_method or CODE_CHALLENGE_PLAIN
+
                 # Verify code challenge
-                if code_data.code_challenge_method == CODE_CHALLENGE_S256:
+                if challenge_method == CODE_CHALLENGE_S256:
                     # PKCE uses base64url encoding, not hex
                     import base64
 
                     verifier_hash = hashlib.sha256(code_verifier.encode()).digest()
                     verifier_challenge = base64.urlsafe_b64encode(verifier_hash).decode().rstrip("=")
-                    if verifier_challenge != code_data.code_challenge:
+                    if not secrets.compare_digest(verifier_challenge, code_data.code_challenge):
                         return None
-                elif code_data.code_challenge_method == CODE_CHALLENGE_PLAIN:
-                    if code_verifier != code_data.code_challenge:
+                elif challenge_method == CODE_CHALLENGE_PLAIN:
+                    if not secrets.compare_digest(code_verifier, code_data.code_challenge):
                         return None
+                else:
+                    return None
 
             # Code is valid, consume it (one-time use)
             await session.delete(f"{self.sandbox_id}:auth_code:{code}")
@@ -288,12 +297,20 @@ class TokenStore(BaseTokenStore):
             logger.debug(f"✓ Token found: user_id={token_data.user_id}")
             return token_data.to_dict()
 
-    async def refresh_access_token(self, refresh_token: str) -> tuple[str, str] | None:
+    async def refresh_access_token(
+        self,
+        refresh_token: str,
+        client_id: str | None = None,
+    ) -> tuple[str, str] | None:
         """
         Refresh MCP access token using refresh token.
 
         Args:
             refresh_token: Refresh token
+            client_id: Client presenting the token. When supplied it must match the
+                client the refresh token was issued to (RFC 6749 section 6), so a
+                leaked token cannot be redeemed by a different client. Optional only
+                for backwards compatibility with existing callers.
 
         Returns:
             New (access_token, refresh_token) tuple or None if invalid
@@ -304,6 +321,10 @@ class TokenStore(BaseTokenStore):
                 return None
 
             refresh_data = RefreshTokenData.from_dict(orjson.loads(refresh_json))
+
+            # Bind the refresh token to the client it was issued to
+            if client_id is not None and refresh_data.client_id != client_id:
+                return None
 
             # Revoke old access token
             old_access_token = refresh_data.access_token
@@ -424,6 +445,7 @@ class TokenStore(BaseTokenStore):
         self,
         client_name: str,
         redirect_uris: list[str],
+        token_endpoint_auth_method: str = DEFAULT_AUTH_METHOD,
     ) -> dict[str, str]:
         """
         Register a new MCP client.
@@ -431,9 +453,13 @@ class TokenStore(BaseTokenStore):
         Args:
             client_name: Client name
             redirect_uris: List of valid redirect URIs
+            token_endpoint_auth_method: How the client will authenticate at the
+                token endpoint (RFC 7591). Clients declaring client_secret_post or
+                client_secret_basic must present their secret to exchange a code or
+                refresh a token; "none" registers a public client.
 
         Returns:
-            Dict with client_id and client_secret
+            Dict with client_id, client_secret and token_endpoint_auth_method
         """
         client_id = secrets.token_urlsafe(16)
         client_secret = secrets.token_urlsafe(32)
@@ -442,6 +468,7 @@ class TokenStore(BaseTokenStore):
             client_name=client_name,
             client_secret=client_secret,
             redirect_uris=redirect_uris,
+            token_endpoint_auth_method=token_endpoint_auth_method,
         )
 
         # Store with configurable TTL (default: 1 year)
@@ -455,7 +482,25 @@ class TokenStore(BaseTokenStore):
         return {
             "client_id": client_id,
             "client_secret": client_secret,
+            "token_endpoint_auth_method": client_data.token_endpoint_auth_method,
         }
+
+    async def get_client(self, client_id: str) -> ClientData | None:
+        """
+        Load a registered client.
+
+        Args:
+            client_id: Client ID
+
+        Returns:
+            Client data, or None if the client is not registered
+        """
+        async with get_session() as session:
+            client_json = await session.get(f"{self.sandbox_id}:client:{client_id}")
+            if not client_json:
+                return None
+
+            return ClientData.from_dict(orjson.loads(client_json))
 
     async def validate_client(
         self,
@@ -466,6 +511,10 @@ class TokenStore(BaseTokenStore):
         """
         Validate MCP client credentials.
 
+        A supplied secret is always checked, but this method does not require one.
+        Use :meth:`authenticate_client` at the token endpoint, where the client's
+        registered token_endpoint_auth_method decides whether a secret is mandatory.
+
         Args:
             client_id: Client ID
             client_secret: Client secret (for confidential clients)
@@ -474,24 +523,62 @@ class TokenStore(BaseTokenStore):
         Returns:
             True if valid
         """
-        async with get_session() as session:
-            client_json = await session.get(f"{self.sandbox_id}:client:{client_id}")
-            if not client_json:
+        client_data = await self.get_client(client_id)
+        if not client_data:
+            return False
+
+        # Validate secret if provided
+        if client_secret is not None:
+            if not secrets.compare_digest(client_data.client_secret, client_secret):
                 return False
 
-            client_data = ClientData.from_dict(orjson.loads(client_json))
+        # Validate redirect URI if provided
+        if redirect_uri is not None:
+            if redirect_uri not in client_data.redirect_uris:
+                return False
 
-            # Validate secret if provided
-            if client_secret is not None:
-                if client_data.client_secret != client_secret:
-                    return False
+        return True
 
-            # Validate redirect URI if provided
-            if redirect_uri is not None:
-                if redirect_uri not in client_data.redirect_uris:
-                    return False
+    async def authenticate_client(
+        self,
+        client_id: str,
+        client_secret: str | None = None,
+        redirect_uri: str | None = None,
+    ) -> bool:
+        """
+        Authenticate a client at the token endpoint (RFC 6749 section 3.2.1).
 
-            return True
+        Unlike :meth:`validate_client`, this enforces the client's registered
+        token_endpoint_auth_method: a client that registered as client_secret_post
+        or client_secret_basic must present a matching secret. Public clients
+        ("none") may omit the secret, but a secret that is supplied and wrong is
+        always rejected.
+
+        Args:
+            client_id: Client ID
+            client_secret: Client secret presented at the token endpoint
+            redirect_uri: Redirect URI to validate
+
+        Returns:
+            True if the client is authenticated
+        """
+        client_data = await self.get_client(client_id)
+        if not client_data:
+            return False
+
+        requires_secret = client_data.token_endpoint_auth_method in CONFIDENTIAL_AUTH_METHODS
+        if requires_secret and not client_secret:
+            return False
+
+        if client_secret is not None:
+            if not secrets.compare_digest(client_data.client_secret, client_secret):
+                return False
+
+        if redirect_uri is not None:
+            if redirect_uri not in client_data.redirect_uris:
+                return False
+
+        return True
 
     # ============================================================================
     # Pending Authorization Storage (for OAuth state management)

--- a/tests/oauth/test_base_token_store.py
+++ b/tests/oauth/test_base_token_store.py
@@ -178,3 +178,76 @@ class TestBaseTokenStore:
         assert valid is True
         invalid = await store.validate_client("invalid_client")
         assert invalid is False
+
+
+class LegacyTokenStore(BaseTokenStore):
+    """A token store written before authenticate_client existed."""
+
+    def __init__(self):
+        self.validate_calls = []
+
+    async def create_authorization_code(
+        self, user_id, client_id, redirect_uri, scope=None, code_challenge=None, code_challenge_method=None
+    ):  # pragma: no cover - not exercised here
+        return "auth_code"
+
+    async def validate_authorization_code(
+        self, code, client_id, redirect_uri, code_verifier=None
+    ):  # pragma: no cover - not exercised here
+        return None
+
+    async def create_access_token(self, user_id, client_id, scope=None):  # pragma: no cover - not exercised here
+        return ("access", "refresh")
+
+    async def validate_access_token(self, token):  # pragma: no cover - not exercised here
+        return None
+
+    async def refresh_access_token(self, refresh_token):  # pragma: no cover - not exercised here
+        return None
+
+    async def link_external_token(
+        self, user_id, access_token, refresh_token=None, expires_in=None, provider="external"
+    ):  # pragma: no cover - not exercised here
+        pass
+
+    async def get_external_token(self, user_id, provider="external"):  # pragma: no cover - not exercised here
+        return None
+
+    async def update_external_token(
+        self, user_id, access_token, refresh_token=None, expires_in=None, provider="external"
+    ):  # pragma: no cover - not exercised here
+        pass
+
+    async def is_external_token_expired(self, user_id, provider="external"):  # pragma: no cover - not exercised here
+        return False
+
+    async def register_client(self, client_name, redirect_uris):  # pragma: no cover - not exercised here
+        return {"client_id": "client123", "client_secret": "secret123"}
+
+    async def validate_client(self, client_id, client_secret=None, redirect_uri=None):
+        self.validate_calls.append((client_id, client_secret, redirect_uri))
+        return client_secret != "wrong-secret"
+
+
+class TestDefaultAuthenticateClient:
+    """The default authenticate_client keeps pre-existing stores working."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_validate_client(self):
+        store = LegacyTokenStore()
+
+        assert await store.authenticate_client("client-a", "s3cret", "http://localhost/cb")
+        assert store.validate_calls == [("client-a", "s3cret", "http://localhost/cb")]
+
+    @pytest.mark.asyncio
+    async def test_passes_through_rejection(self):
+        store = LegacyTokenStore()
+
+        assert not await store.authenticate_client("client-a", "wrong-secret")
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_no_credentials(self):
+        store = LegacyTokenStore()
+
+        assert await store.authenticate_client("client-a")
+        assert store.validate_calls == [("client-a", None, None)]

--- a/tests/oauth/test_client_auth.py
+++ b/tests/oauth/test_client_auth.py
@@ -1,0 +1,155 @@
+"""Tests for token endpoint client credential extraction (RFC 6749 section 2.3.1)."""
+
+import base64
+
+import pytest
+
+from chuk_mcp_server.oauth.client_auth import (
+    ClientCredentials,
+    CredentialError,
+    extract_client_credentials,
+    parse_basic_auth,
+)
+
+
+def basic_header(client_id: str, client_secret: str) -> str:
+    """Build an Authorization: Basic header value."""
+    encoded = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+class TestParseBasicAuth:
+    """Test parse_basic_auth."""
+
+    def test_none_header(self):
+        assert parse_basic_auth(None) == (None, None)
+
+    def test_empty_header(self):
+        assert parse_basic_auth("") == (None, None)
+
+    def test_valid_credentials(self):
+        assert parse_basic_auth(basic_header("abc", "s3cret")) == ("abc", "s3cret")
+
+    def test_scheme_is_case_insensitive(self):
+        encoded = base64.b64encode(b"abc:s3cret").decode()
+        assert parse_basic_auth(f"basic {encoded}") == ("abc", "s3cret")
+        assert parse_basic_auth(f"BASIC {encoded}") == ("abc", "s3cret")
+
+    def test_other_scheme_ignored(self):
+        # A Bearer token is not client authentication.
+        assert parse_basic_auth("Bearer some-access-token") == (None, None)
+
+    def test_percent_encoded_values_are_unquoted(self):
+        # RFC 6749 2.3.1 form-urlencodes both halves before base64.
+        header = basic_header("client%20id", "secret%2Fwith%2Fslashes")
+        assert parse_basic_auth(header) == ("client id", "secret/with/slashes")
+
+    def test_empty_secret_is_allowed(self):
+        assert parse_basic_auth(basic_header("abc", "")) == ("abc", "")
+
+    def test_secret_containing_colon(self):
+        # Only the first colon separates the two halves.
+        header = basic_header("abc", "a:b:c")
+        assert parse_basic_auth(header) == ("abc", "a:b:c")
+
+    def test_missing_credentials_raises(self):
+        with pytest.raises(ValueError, match="missing"):
+            parse_basic_auth("Basic ")
+
+    def test_invalid_base64_raises(self):
+        with pytest.raises(ValueError, match="base64"):
+            parse_basic_auth("Basic not-valid-base64!!!")
+
+    def test_non_utf8_raises(self):
+        encoded = base64.b64encode(b"\xff\xfe\xfd").decode()
+        with pytest.raises(ValueError, match="base64"):
+            parse_basic_auth(f"Basic {encoded}")
+
+    def test_missing_colon_raises(self):
+        encoded = base64.b64encode(b"no-colon-here").decode()
+        with pytest.raises(ValueError, match="client_id:client_secret"):
+            parse_basic_auth(f"Basic {encoded}")
+
+    def test_missing_client_id_raises(self):
+        encoded = base64.b64encode(b":only-a-secret").decode()
+        with pytest.raises(ValueError, match="client_id"):
+            parse_basic_auth(f"Basic {encoded}")
+
+
+class TestExtractClientCredentials:
+    """Test extract_client_credentials."""
+
+    def test_nothing_presented(self):
+        creds = extract_client_credentials(None, None, None)
+        assert creds.is_valid
+        assert creds.client_id is None
+        assert creds.client_secret is None
+
+    def test_body_only(self):
+        creds = extract_client_credentials(None, "abc", "s3cret")
+        assert creds.is_valid
+        assert creds.client_id == "abc"
+        assert creds.client_secret == "s3cret"
+
+    def test_header_only(self):
+        creds = extract_client_credentials(basic_header("abc", "s3cret"), None, None)
+        assert creds.is_valid
+        assert creds.client_id == "abc"
+        assert creds.client_secret == "s3cret"
+
+    def test_header_and_matching_body(self):
+        creds = extract_client_credentials(basic_header("abc", "s3cret"), "abc", "s3cret")
+        assert creds.is_valid
+        assert creds.client_id == "abc"
+        assert creds.client_secret == "s3cret"
+
+    def test_public_client_sends_id_only(self):
+        creds = extract_client_credentials(None, "abc", None)
+        assert creds.is_valid
+        assert creds.client_id == "abc"
+        assert creds.client_secret is None
+
+    def test_empty_body_secret_is_treated_as_absent(self):
+        creds = extract_client_credentials(None, "abc", "")
+        assert creds.is_valid
+        assert creds.client_secret is None
+
+    def test_malformed_header(self):
+        creds = extract_client_credentials("Basic !!!not-base64", None, None)
+        assert not creds.is_valid
+        assert creds.error is CredentialError.MALFORMED_HEADER
+
+    def test_client_id_mismatch(self):
+        creds = extract_client_credentials(basic_header("abc", "s3cret"), "different", None)
+        assert not creds.is_valid
+        assert creds.error is CredentialError.CLIENT_ID_MISMATCH
+
+    def test_client_secret_mismatch(self):
+        creds = extract_client_credentials(basic_header("abc", "s3cret"), "abc", "other-secret")
+        assert not creds.is_valid
+        assert creds.error is CredentialError.CLIENT_SECRET_MISMATCH
+
+    def test_header_secret_wins_when_body_omits_it(self):
+        creds = extract_client_credentials(basic_header("abc", "s3cret"), "abc", None)
+        assert creds.is_valid
+        assert creds.client_secret == "s3cret"
+
+    def test_body_secret_used_when_header_secret_empty(self):
+        creds = extract_client_credentials(basic_header("abc", ""), "abc", "body-secret")
+        assert creds.is_valid
+        assert creds.client_secret == "body-secret"
+
+
+class TestClientCredentials:
+    """Test the ClientCredentials value object."""
+
+    def test_is_valid_without_error(self):
+        assert ClientCredentials(client_id="abc").is_valid
+
+    def test_is_not_valid_with_error(self):
+        assert not ClientCredentials(error=CredentialError.MALFORMED_HEADER).is_valid
+
+    def test_is_frozen(self):
+        creds = ClientCredentials(client_id="abc")
+        with pytest.raises(AttributeError):
+            creds.client_id = "changed"  # type: ignore[misc]

--- a/tests/oauth/test_client_authentication.py
+++ b/tests/oauth/test_client_authentication.py
@@ -1,0 +1,652 @@
+"""
+Regression tests for OAuth client authentication at the token endpoint.
+
+These cover the guarantees the server's RFC 8414 metadata advertises:
+
+- a client that registers as confidential must present its secret to exchange an
+  authorization code or refresh a token (RFC 6749 sections 3.2.1 and 6)
+- a wrong secret is rejected, whether or not one was required
+- a refresh token is bound to the client it was issued to
+- a PKCE challenge is verified even when the client omits code_challenge_method
+"""
+
+import base64
+import hashlib
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from starlette.requests import Request
+
+from chuk_mcp_server.oauth.base_provider import BaseOAuthProvider
+from chuk_mcp_server.oauth.constants import (
+    AUTH_METHOD_CLIENT_SECRET_BASIC,
+    AUTH_METHOD_CLIENT_SECRET_POST,
+    AUTH_METHOD_NONE,
+    CODE_CHALLENGE_PLAIN,
+    CODE_CHALLENGE_S256,
+    ERROR_INVALID_CLIENT,
+    ERROR_INVALID_REQUEST,
+    GRANT_AUTHORIZATION_CODE,
+    GRANT_REFRESH_TOKEN,
+    HTTP_BAD_REQUEST,
+    HTTP_UNAUTHORIZED,
+)
+from chuk_mcp_server.oauth.middleware import OAuthMiddleware
+from chuk_mcp_server.oauth.models import OAuthToken, TokenError
+from chuk_mcp_server.oauth.token_store import TokenStore
+
+from .test_token_store import MockSession
+
+REDIRECT_URI = "http://localhost:9999/callback"
+USER_ID = "victim-user-1"
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """A TokenStore backed by an in-memory session."""
+    session = MockSession()
+    monkeypatch.setattr(
+        "chuk_mcp_server.oauth.token_store.get_session",
+        lambda: session,
+    )
+    return TokenStore(sandbox_id="test-client-auth")
+
+
+def s256_challenge(verifier: str) -> str:
+    """Compute the S256 challenge for a verifier."""
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+async def register(store: TokenStore, auth_method: str) -> tuple[str, str]:
+    """Register a client and return (client_id, client_secret)."""
+    credentials = await store.register_client(
+        client_name="Test App",
+        redirect_uris=[REDIRECT_URI],
+        token_endpoint_auth_method=auth_method,
+    )
+    return credentials["client_id"], credentials["client_secret"]
+
+
+class TestRegistrationRecordsAuthMethod:
+    """A client's declared auth method must survive registration."""
+
+    @pytest.mark.asyncio
+    async def test_declared_method_is_persisted(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_CLIENT_SECRET_POST)
+
+        client = await store.get_client(client_id)
+        assert client is not None
+        assert client.token_endpoint_auth_method == AUTH_METHOD_CLIENT_SECRET_POST
+
+    @pytest.mark.asyncio
+    async def test_basic_method_is_persisted(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_CLIENT_SECRET_BASIC)
+
+        client = await store.get_client(client_id)
+        assert client.token_endpoint_auth_method == AUTH_METHOD_CLIENT_SECRET_BASIC
+
+    @pytest.mark.asyncio
+    async def test_undeclared_client_is_public(self, store):
+        credentials = await store.register_client(
+            client_name="Test App",
+            redirect_uris=[REDIRECT_URI],
+        )
+
+        client = await store.get_client(credentials["client_id"])
+        assert client.token_endpoint_auth_method == AUTH_METHOD_NONE
+
+    @pytest.mark.asyncio
+    async def test_registration_returns_the_method(self, store):
+        credentials = await store.register_client(
+            client_name="Test App",
+            redirect_uris=[REDIRECT_URI],
+            token_endpoint_auth_method=AUTH_METHOD_CLIENT_SECRET_POST,
+        )
+
+        assert credentials["token_endpoint_auth_method"] == AUTH_METHOD_CLIENT_SECRET_POST
+
+    @pytest.mark.asyncio
+    async def test_unknown_client_is_not_found(self, store):
+        assert await store.get_client("never-registered") is None
+
+
+class TestConfidentialClientAuthentication:
+    """Confidential clients must present a matching secret."""
+
+    @pytest.mark.asyncio
+    async def test_correct_secret_authenticates(self, store):
+        client_id, client_secret = await register(store, AUTH_METHOD_CLIENT_SECRET_POST)
+
+        assert await store.authenticate_client(client_id, client_secret)
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_is_rejected(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_CLIENT_SECRET_POST)
+
+        assert not await store.authenticate_client(client_id)
+        assert not await store.authenticate_client(client_id, None)
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_is_rejected(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_CLIENT_SECRET_POST)
+
+        assert not await store.authenticate_client(client_id, "not-the-secret")
+
+    @pytest.mark.asyncio
+    async def test_empty_secret_is_rejected(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_CLIENT_SECRET_BASIC)
+
+        assert not await store.authenticate_client(client_id, "")
+
+    @pytest.mark.asyncio
+    async def test_basic_client_also_requires_a_secret(self, store):
+        client_id, client_secret = await register(store, AUTH_METHOD_CLIENT_SECRET_BASIC)
+
+        assert not await store.authenticate_client(client_id)
+        assert await store.authenticate_client(client_id, client_secret)
+
+    @pytest.mark.asyncio
+    async def test_unregistered_client_is_rejected(self, store):
+        assert not await store.authenticate_client("never-registered", "any-secret")
+
+    @pytest.mark.asyncio
+    async def test_redirect_uri_is_still_checked(self, store):
+        client_id, client_secret = await register(store, AUTH_METHOD_CLIENT_SECRET_POST)
+
+        assert await store.authenticate_client(client_id, client_secret, REDIRECT_URI)
+        assert not await store.authenticate_client(client_id, client_secret, "http://evil.example/cb")
+
+
+class TestPublicClientAuthentication:
+    """Public clients may omit a secret, but a wrong one is never accepted."""
+
+    @pytest.mark.asyncio
+    async def test_no_secret_is_accepted(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_NONE)
+
+        assert await store.authenticate_client(client_id)
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_is_still_rejected(self, store):
+        client_id, _ = await register(store, AUTH_METHOD_NONE)
+
+        assert not await store.authenticate_client(client_id, "not-the-secret")
+
+    @pytest.mark.asyncio
+    async def test_correct_secret_is_accepted(self, store):
+        client_id, client_secret = await register(store, AUTH_METHOD_NONE)
+
+        assert await store.authenticate_client(client_id, client_secret)
+
+
+class TestRefreshTokenClientBinding:
+    """A refresh token belongs to one client (RFC 6749 section 6)."""
+
+    @pytest.mark.asyncio
+    async def test_issuing_client_can_refresh(self, store):
+        _, refresh_token = await store.create_access_token(USER_ID, "client-a")
+
+        assert await store.refresh_access_token(refresh_token, client_id="client-a") is not None
+
+    @pytest.mark.asyncio
+    async def test_other_client_cannot_refresh(self, store):
+        _, refresh_token = await store.create_access_token(USER_ID, "client-a")
+
+        assert await store.refresh_access_token(refresh_token, client_id="client-b") is None
+
+    @pytest.mark.asyncio
+    async def test_rejected_refresh_does_not_consume_the_token(self, store):
+        _, refresh_token = await store.create_access_token(USER_ID, "client-a")
+
+        assert await store.refresh_access_token(refresh_token, client_id="client-b") is None
+        # The legitimate client can still use it.
+        assert await store.refresh_access_token(refresh_token, client_id="client-a") is not None
+
+    @pytest.mark.asyncio
+    async def test_omitted_client_id_keeps_legacy_behaviour(self, store):
+        _, refresh_token = await store.create_access_token(USER_ID, "client-a")
+
+        assert await store.refresh_access_token(refresh_token) is not None
+
+    @pytest.mark.asyncio
+    async def test_unknown_refresh_token(self, store):
+        assert await store.refresh_access_token("never-issued", client_id="client-a") is None
+
+
+class TestPkceEnforcement:
+    """A recorded challenge must always be verified."""
+
+    async def _code(self, store, **kwargs):
+        return await store.create_authorization_code(
+            user_id=USER_ID,
+            client_id="client-a",
+            redirect_uri=REDIRECT_URI,
+            **kwargs,
+        )
+
+    async def _validate(self, store, code, code_verifier=None):
+        return await store.validate_authorization_code(
+            code=code,
+            client_id="client-a",
+            redirect_uri=REDIRECT_URI,
+            code_verifier=code_verifier,
+        )
+
+    @pytest.mark.asyncio
+    async def test_s256_requires_matching_verifier(self, store):
+        verifier = "a" * 64
+        code = await self._code(
+            store,
+            code_challenge=s256_challenge(verifier),
+            code_challenge_method=CODE_CHALLENGE_S256,
+        )
+
+        assert await self._validate(store, code, verifier) is not None
+
+    @pytest.mark.asyncio
+    async def test_s256_rejects_wrong_verifier(self, store):
+        code = await self._code(
+            store,
+            code_challenge=s256_challenge("a" * 64),
+            code_challenge_method=CODE_CHALLENGE_S256,
+        )
+
+        assert await self._validate(store, code, "b" * 64) is None
+
+    @pytest.mark.asyncio
+    async def test_s256_rejects_missing_verifier(self, store):
+        code = await self._code(
+            store,
+            code_challenge=s256_challenge("a" * 64),
+            code_challenge_method=CODE_CHALLENGE_S256,
+        )
+
+        assert await self._validate(store, code) is None
+
+    @pytest.mark.asyncio
+    async def test_plain_requires_matching_verifier(self, store):
+        code = await self._code(
+            store,
+            code_challenge="the-verifier",
+            code_challenge_method=CODE_CHALLENGE_PLAIN,
+        )
+
+        assert await self._validate(store, code, "the-verifier") is not None
+
+    @pytest.mark.asyncio
+    async def test_plain_rejects_wrong_verifier(self, store):
+        code = await self._code(
+            store,
+            code_challenge="the-verifier",
+            code_challenge_method=CODE_CHALLENGE_PLAIN,
+        )
+
+        assert await self._validate(store, code, "wrong") is None
+
+    @pytest.mark.asyncio
+    async def test_omitted_method_defaults_to_plain(self, store):
+        # RFC 7636 4.3. Previously an absent method meant no verification at all.
+        code = await self._code(store, code_challenge="the-verifier")
+
+        assert await self._validate(store, code, "the-verifier") is not None
+
+    @pytest.mark.asyncio
+    async def test_omitted_method_rejects_arbitrary_verifier(self, store):
+        code = await self._code(store, code_challenge="the-verifier")
+
+        assert await self._validate(store, code, "anything-at-all") is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_method_fails_closed(self, store):
+        code = await self._code(
+            store,
+            code_challenge="the-verifier",
+            code_challenge_method="S512",
+        )
+
+        assert await self._validate(store, code, "the-verifier") is None
+        assert await self._validate(store, code, "anything-at-all") is None
+
+    @pytest.mark.asyncio
+    async def test_no_challenge_needs_no_verifier(self, store):
+        code = await self._code(store)
+
+        assert await self._validate(store, code) is not None
+
+
+# ============================================================================
+# Token endpoint (HTTP layer)
+# ============================================================================
+
+
+class RecordingProvider(BaseOAuthProvider):
+    """Provider that records the credentials the middleware hands it."""
+
+    def __init__(self, expected_secret: str | None = None):
+        self.expected_secret = expected_secret
+        self.received: dict[str, object] = {}
+
+    async def exchange_authorization_code(self, code, client_id, redirect_uri, code_verifier=None, client_secret=None):
+        self.received = {
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+            "client_secret": client_secret,
+        }
+        if self.expected_secret is not None and client_secret != self.expected_secret:
+            raise TokenError(ERROR_INVALID_CLIENT, "Client authentication failed")
+        return OAuthToken(access_token="issued-access-token", refresh_token="issued-refresh-token")
+
+    async def exchange_refresh_token(self, refresh_token, client_id, scope=None, client_secret=None):
+        self.received = {
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+            "scope": scope,
+            "client_secret": client_secret,
+        }
+        if self.expected_secret is not None and client_secret != self.expected_secret:
+            raise TokenError(ERROR_INVALID_CLIENT, "Client authentication failed")
+        return OAuthToken(access_token="refreshed-access-token")
+
+    async def authorize(self, params):
+        return {"code": "auth-code", "state": params.state}
+
+    async def validate_access_token(self, token):
+        return {"user_id": USER_ID}
+
+    async def register_client(self, client_metadata):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+
+class LegacyProvider(BaseOAuthProvider):
+    """Provider written before client authentication existed."""
+
+    def __init__(self):
+        self.called = False
+
+    async def exchange_authorization_code(self, code, client_id, redirect_uri, code_verifier=None):
+        self.called = True
+        return OAuthToken(access_token="legacy-access-token")
+
+    async def exchange_refresh_token(self, refresh_token, client_id, scope=None):
+        self.called = True
+        return OAuthToken(access_token="legacy-access-token")
+
+    async def authorize(self, params):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+    async def validate_access_token(self, token):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+    async def register_client(self, client_metadata):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+
+def build_middleware(provider):
+    """Wire a provider into OAuthMiddleware with a stubbed MCP server."""
+    mcp_server = Mock()
+    mcp_server.endpoint = Mock(return_value=lambda f: f)
+    return OAuthMiddleware(mcp_server=mcp_server, provider=provider)
+
+
+def token_request(form: dict, headers: dict | None = None) -> Request:
+    """Build a token endpoint request."""
+    request = Mock(spec=Request)
+    request.form = AsyncMock(return_value=form)
+    request.headers = headers or {}
+    return request
+
+
+def basic_header(client_id: str, client_secret: str) -> str:
+    """Build an Authorization: Basic header value."""
+    encoded = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+def code_form(**overrides) -> dict:
+    """Build an authorization_code token request body."""
+    return {
+        "grant_type": GRANT_AUTHORIZATION_CODE,
+        "code": "the-code",
+        "client_id": "client-a",
+        "redirect_uri": REDIRECT_URI,
+        **overrides,
+    }
+
+
+class TestTokenEndpointCredentialExtraction:
+    """The token endpoint must read a secret from either RFC 6749 location."""
+
+    @pytest.mark.asyncio
+    async def test_secret_from_post_body(self):
+        provider = RecordingProvider()
+        middleware = build_middleware(provider)
+
+        response = await middleware._token_endpoint(token_request(code_form(client_secret="s3cret")))
+
+        assert response.status_code == 200
+        assert provider.received["client_secret"] == "s3cret"
+
+    @pytest.mark.asyncio
+    async def test_secret_from_basic_header(self):
+        provider = RecordingProvider()
+        middleware = build_middleware(provider)
+
+        response = await middleware._token_endpoint(
+            token_request(
+                {"grant_type": GRANT_AUTHORIZATION_CODE, "code": "the-code", "redirect_uri": REDIRECT_URI},
+                {"authorization": basic_header("client-a", "s3cret")},
+            )
+        )
+
+        assert response.status_code == 200
+        assert provider.received["client_id"] == "client-a"
+        assert provider.received["client_secret"] == "s3cret"
+
+    @pytest.mark.asyncio
+    async def test_no_secret_reaches_provider_as_none(self):
+        provider = RecordingProvider()
+        middleware = build_middleware(provider)
+
+        await middleware._token_endpoint(token_request(code_form()))
+
+        assert provider.received["client_secret"] is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_grant_forwards_the_secret(self):
+        provider = RecordingProvider()
+        middleware = build_middleware(provider)
+
+        response = await middleware._token_endpoint(
+            token_request(
+                {
+                    "grant_type": GRANT_REFRESH_TOKEN,
+                    "refresh_token": "the-refresh-token",
+                    "client_id": "client-a",
+                    "client_secret": "s3cret",
+                }
+            )
+        )
+
+        assert response.status_code == 200
+        assert provider.received["client_secret"] == "s3cret"
+
+    @pytest.mark.asyncio
+    async def test_malformed_basic_header_is_unauthorized(self):
+        middleware = build_middleware(RecordingProvider())
+
+        response = await middleware._token_endpoint(
+            token_request(code_form(), {"authorization": "Basic !!!not-base64"})
+        )
+
+        assert response.status_code == HTTP_UNAUTHORIZED
+        assert response.headers["www-authenticate"] == 'Basic realm="oauth"'
+        assert json.loads(response.body)["error"] == ERROR_INVALID_CLIENT
+
+    @pytest.mark.asyncio
+    async def test_client_id_mismatch_is_a_bad_request(self):
+        middleware = build_middleware(RecordingProvider())
+
+        response = await middleware._token_endpoint(
+            token_request(code_form(client_id="other"), {"authorization": basic_header("client-a", "s3cret")})
+        )
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        assert json.loads(response.body)["error"] == ERROR_INVALID_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_conflicting_secrets_are_unauthorized(self):
+        middleware = build_middleware(RecordingProvider())
+
+        response = await middleware._token_endpoint(
+            token_request(
+                code_form(client_secret="body-secret"),
+                {"authorization": basic_header("client-a", "header-secret")},
+            )
+        )
+
+        assert response.status_code == HTTP_UNAUTHORIZED
+        assert json.loads(response.body)["error"] == ERROR_INVALID_CLIENT
+
+
+class TestTokenEndpointRejection:
+    """A provider that refuses the client must produce a 401."""
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_is_unauthorized(self):
+        middleware = build_middleware(RecordingProvider(expected_secret="right-secret"))
+
+        response = await middleware._token_endpoint(token_request(code_form(client_secret="wrong-secret")))
+
+        assert response.status_code == HTTP_UNAUTHORIZED
+        assert response.headers["www-authenticate"] == 'Basic realm="oauth"'
+        assert json.loads(response.body)["error"] == ERROR_INVALID_CLIENT
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_is_unauthorized(self):
+        middleware = build_middleware(RecordingProvider(expected_secret="right-secret"))
+
+        response = await middleware._token_endpoint(token_request(code_form()))
+
+        assert response.status_code == HTTP_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_refresh_grant_rejection_is_unauthorized(self):
+        middleware = build_middleware(RecordingProvider(expected_secret="right-secret"))
+
+        response = await middleware._token_endpoint(
+            token_request(
+                {
+                    "grant_type": GRANT_REFRESH_TOKEN,
+                    "refresh_token": "the-refresh-token",
+                    "client_id": "client-a",
+                }
+            )
+        )
+
+        assert response.status_code == HTTP_UNAUTHORIZED
+
+
+class TestLegacyProviderCompatibility:
+    """Providers written against the old interface keep working."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_provider_still_exchanges_without_a_secret(self):
+        provider = LegacyProvider()
+        middleware = build_middleware(provider)
+
+        response = await middleware._token_endpoint(token_request(code_form()))
+
+        assert response.status_code == 200
+        assert provider.called
+
+    @pytest.mark.asyncio
+    async def test_legacy_provider_still_refreshes_without_a_secret(self):
+        provider = LegacyProvider()
+        middleware = build_middleware(provider)
+
+        response = await middleware._token_endpoint(
+            token_request(
+                {
+                    "grant_type": GRANT_REFRESH_TOKEN,
+                    "refresh_token": "the-refresh-token",
+                    "client_id": "client-a",
+                }
+            )
+        )
+
+        assert response.status_code == 200
+        assert provider.called
+
+    @pytest.mark.asyncio
+    async def test_secret_sent_to_a_legacy_provider_is_refused_not_ignored(self):
+        # Silently dropping the credential would be worse than failing loudly.
+        provider = LegacyProvider()
+        middleware = build_middleware(provider)
+
+        response = await middleware._token_endpoint(token_request(code_form(client_secret="s3cret")))
+
+        assert response.status_code == HTTP_UNAUTHORIZED
+        assert not provider.called
+
+
+class TestAuthorizeEndpointPkceMethod:
+    """A challenge without a method must still be recorded as verifiable."""
+
+    def test_explicit_s256_is_kept(self):
+        assert OAuthMiddleware._resolve_code_challenge_method("chal", CODE_CHALLENGE_S256) == CODE_CHALLENGE_S256
+
+    def test_explicit_plain_is_kept(self):
+        assert OAuthMiddleware._resolve_code_challenge_method("chal", CODE_CHALLENGE_PLAIN) == CODE_CHALLENGE_PLAIN
+
+    def test_omitted_method_becomes_plain(self):
+        assert OAuthMiddleware._resolve_code_challenge_method("chal", None) == CODE_CHALLENGE_PLAIN
+
+    def test_no_challenge_means_no_method(self):
+        assert OAuthMiddleware._resolve_code_challenge_method(None, None) is None
+
+    def test_unsupported_method_is_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported code_challenge_method"):
+            OAuthMiddleware._resolve_code_challenge_method("chal", "S512")
+
+
+class TestAuthorizeEndpointRejectsBadPkce:
+    """An unsupported PKCE method must not silently produce an unverifiable code."""
+
+    @pytest.mark.asyncio
+    async def test_unsupported_method_redirects_with_an_error(self):
+        provider = RecordingProvider()
+        middleware = build_middleware(provider)
+
+        request = Mock(spec=Request)
+        request.query_params = {
+            "response_type": "code",
+            "client_id": "client-a",
+            "redirect_uri": REDIRECT_URI,
+            "code_challenge": "chal",
+            "code_challenge_method": "S512",
+            "state": "mcp-state",
+        }
+
+        response = await middleware._authorize_endpoint(request)
+
+        assert response.status_code in (302, 307)
+        assert response.headers["location"].startswith(REDIRECT_URI)
+        assert "error=server_error" in response.headers["location"]
+        assert "state=mcp-state" in response.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_error_page_when_no_redirect_uri(self):
+        provider = RecordingProvider()
+        middleware = build_middleware(provider)
+
+        request = Mock(spec=Request)
+        request.query_params = {"response_type": "code", "client_id": "client-a"}
+
+        response = await middleware._authorize_endpoint(request)
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        assert b"Authorization Error" in response.body

--- a/tests/oauth/test_client_authentication.py
+++ b/tests/oauth/test_client_authentication.py
@@ -30,6 +30,7 @@ from chuk_mcp_server.oauth.constants import (
     GRANT_AUTHORIZATION_CODE,
     GRANT_REFRESH_TOKEN,
     HTTP_BAD_REQUEST,
+    HTTP_INTERNAL_SERVER_ERROR,
     HTTP_UNAUTHORIZED,
 )
 from chuk_mcp_server.oauth.middleware import OAuthMiddleware
@@ -324,9 +325,13 @@ class TestPkceEnforcement:
 class RecordingProvider(BaseOAuthProvider):
     """Provider that records the credentials the middleware hands it."""
 
-    def __init__(self, expected_secret: str | None = None):
+    def __init__(self, expected_secret: str | None = None, redirect_uri_registered: bool = False):
         self.expected_secret = expected_secret
+        self.redirect_uri_registered = redirect_uri_registered
         self.received: dict[str, object] = {}
+
+    async def validate_redirect_uri(self, client_id, redirect_uri):
+        return self.redirect_uri_registered
 
     async def exchange_authorization_code(self, code, client_id, redirect_uri, code_verifier=None, client_secret=None):
         self.received = {
@@ -613,25 +618,29 @@ class TestAuthorizeEndpointPkceMethod:
             OAuthMiddleware._resolve_code_challenge_method("chal", "S512")
 
 
+def authorize_request(**overrides) -> Request:
+    """Build an authorization endpoint request."""
+    request = Mock(spec=Request)
+    request.query_params = {
+        "response_type": "code",
+        "client_id": "client-a",
+        "redirect_uri": REDIRECT_URI,
+        **overrides,
+    }
+    return request
+
+
 class TestAuthorizeEndpointRejectsBadPkce:
     """An unsupported PKCE method must not silently produce an unverifiable code."""
 
     @pytest.mark.asyncio
     async def test_unsupported_method_redirects_with_an_error(self):
-        provider = RecordingProvider()
+        provider = RecordingProvider(redirect_uri_registered=True)
         middleware = build_middleware(provider)
 
-        request = Mock(spec=Request)
-        request.query_params = {
-            "response_type": "code",
-            "client_id": "client-a",
-            "redirect_uri": REDIRECT_URI,
-            "code_challenge": "chal",
-            "code_challenge_method": "S512",
-            "state": "mcp-state",
-        }
-
-        response = await middleware._authorize_endpoint(request)
+        response = await middleware._authorize_endpoint(
+            authorize_request(code_challenge="chal", code_challenge_method="S512", state="mcp-state")
+        )
 
         assert response.status_code in (302, 307)
         assert response.headers["location"].startswith(REDIRECT_URI)
@@ -640,8 +649,7 @@ class TestAuthorizeEndpointRejectsBadPkce:
 
     @pytest.mark.asyncio
     async def test_error_page_when_no_redirect_uri(self):
-        provider = RecordingProvider()
-        middleware = build_middleware(provider)
+        middleware = build_middleware(RecordingProvider())
 
         request = Mock(spec=Request)
         request.query_params = {"response_type": "code", "client_id": "client-a"}
@@ -650,3 +658,117 @@ class TestAuthorizeEndpointRejectsBadPkce:
 
         assert response.status_code == HTTP_BAD_REQUEST
         assert b"Authorization Error" in response.body
+
+
+class TestAuthorizeErrorRedirectIsValidated:
+    """RFC 6749 4.1.2.1 — never auto-redirect an error to an unvalidated URI."""
+
+    @pytest.mark.asyncio
+    async def test_unregistered_redirect_uri_gets_an_error_page(self):
+        # The attacker's URI is not registered, so the error must not be sent there.
+        provider = RecordingProvider(redirect_uri_registered=False)
+        middleware = build_middleware(provider)
+
+        response = await middleware._authorize_endpoint(
+            authorize_request(
+                redirect_uri="http://evil.example/steal",
+                code_challenge_method="S512",
+                state="mcp-state",
+            )
+        )
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        assert b"Authorization Error" in response.body
+        assert "location" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_registered_redirect_uri_still_receives_the_error(self):
+        provider = RecordingProvider(redirect_uri_registered=True)
+        middleware = build_middleware(provider)
+
+        response = await middleware._authorize_endpoint(
+            authorize_request(redirect_uri=REDIRECT_URI, code_challenge_method="S512", state="mcp-state")
+        )
+
+        assert response.status_code in (302, 307)
+        assert response.headers["location"].startswith(REDIRECT_URI)
+        assert "error=server_error" in response.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_missing_client_id_gets_an_error_page(self):
+        # Without a client_id there is nothing to validate the URI against.
+        provider = RecordingProvider(redirect_uri_registered=True)
+        middleware = build_middleware(provider)
+
+        request = Mock(spec=Request)
+        request.query_params = {"response_type": "code", "redirect_uri": "http://evil.example/steal"}
+
+        response = await middleware._authorize_endpoint(request)
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        assert "location" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_a_raising_validator_refuses_the_redirect(self):
+        provider = RecordingProvider(redirect_uri_registered=True)
+        provider.validate_redirect_uri = AsyncMock(side_effect=RuntimeError("store down"))
+        middleware = build_middleware(provider)
+
+        response = await middleware._authorize_endpoint(authorize_request(code_challenge_method="S512"))
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        assert "location" not in response.headers
+
+
+class TestExternalCallbackLinkSafety:
+    """The callback page renders the redirect URI as a link, so re-check it."""
+
+    def _middleware_with_callback(self, redirect_uri):
+        provider = RecordingProvider()
+        provider.handle_external_callback = AsyncMock(
+            return_value={"code": "the-code", "state": "mcp-state", "redirect_uri": redirect_uri}
+        )
+        return build_middleware(provider)
+
+    def _callback_request(self):
+        request = Mock(spec=Request)
+        request.query_params = {"code": "google-code", "state": "google-state"}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_safe_redirect_uri_renders_the_page(self):
+        middleware = self._middleware_with_callback(REDIRECT_URI)
+
+        response = await middleware._external_callback_endpoint(self._callback_request())
+
+        assert response.status_code == 200
+        assert b"Authorization Successful" in response.body
+
+    @pytest.mark.asyncio
+    async def test_javascript_uri_is_refused(self):
+        # Defence in depth: registration rejects these, but a client stored before
+        # that check existed must not get a javascript: link rendered for it.
+        middleware = self._middleware_with_callback("javascript:alert(document.cookie)")
+
+        response = await middleware._external_callback_endpoint(self._callback_request())
+
+        assert response.status_code == HTTP_INTERNAL_SERVER_ERROR
+        assert b"javascript:" not in response.body
+        assert b"Authorization Error" in response.body
+
+    @pytest.mark.asyncio
+    async def test_data_uri_is_refused(self):
+        middleware = self._middleware_with_callback("data:text/html,<script>alert(1)</script>")
+
+        response = await middleware._external_callback_endpoint(self._callback_request())
+
+        assert response.status_code == HTTP_INTERNAL_SERVER_ERROR
+        assert b"script" not in response.body
+
+    @pytest.mark.asyncio
+    async def test_code_is_appended_to_an_existing_query_string(self):
+        middleware = self._middleware_with_callback("https://app.example/cb?tenant=acme")
+
+        response = await middleware._external_callback_endpoint(self._callback_request())
+
+        assert b"tenant=acme&amp;code=the-code" in response.body

--- a/tests/oauth/test_compat.py
+++ b/tests/oauth/test_compat.py
@@ -1,0 +1,110 @@
+"""Tests for the OAuth extension point compatibility helpers."""
+
+import functools
+from unittest.mock import patch
+
+from chuk_mcp_server.oauth.compat import _accepts, supports_keyword
+
+
+class ModernProvider:
+    """Stand-in for a provider written against the current interface."""
+
+    async def exchange(self, code, client_id, client_secret=None):
+        return code, client_id, client_secret
+
+
+class LegacyProvider:
+    """Stand-in for a provider written before client authentication existed."""
+
+    async def exchange(self, code, client_id):
+        return code, client_id
+
+
+class KwargsProvider:
+    """A provider that forwards everything."""
+
+    async def exchange(self, code, **kwargs):
+        return code, kwargs
+
+
+class TestSupportsKeyword:
+    """Test supports_keyword."""
+
+    def test_plain_function_with_keyword(self):
+        def fn(a, client_secret=None):
+            return a, client_secret
+
+        assert supports_keyword(fn, "client_secret")
+
+    def test_plain_function_without_keyword(self):
+        def fn(a):
+            return a
+
+        assert not supports_keyword(fn, "client_secret")
+
+    def test_bound_method_with_keyword(self):
+        assert supports_keyword(ModernProvider().exchange, "client_secret")
+
+    def test_bound_method_without_keyword(self):
+        assert not supports_keyword(LegacyProvider().exchange, "client_secret")
+
+    def test_var_keyword_accepts_anything(self):
+        assert supports_keyword(KwargsProvider().exchange, "client_secret")
+        assert supports_keyword(KwargsProvider().exchange, "anything_at_all")
+
+    def test_required_positional_or_keyword_counts(self):
+        def fn(client_secret):
+            return client_secret
+
+        assert supports_keyword(fn, "client_secret")
+
+    def test_positional_only_does_not_count(self):
+        def fn(client_secret, /):
+            return client_secret
+
+        assert not supports_keyword(fn, "client_secret")
+
+    def test_unwraps_decorated_functions(self):
+        def decorate(f):
+            @functools.wraps(f)
+            def wrapper(*args, **kwargs):
+                return f(*args, **kwargs)
+
+            return wrapper
+
+        @decorate
+        def fn(a, client_secret=None):
+            return a, client_secret
+
+        assert supports_keyword(fn, "client_secret")
+
+    def test_builtin_keyword_only_params_are_found(self):
+        # print(*values, sep=..., end=...) — keyword-only params still count.
+        assert supports_keyword(print, "sep")
+        assert not supports_keyword(print, "client_secret")
+
+    def test_uninspectable_callable_falls_back_to_permissive(self):
+        # Some C callables have no signature; assume the modern one and let the
+        # call itself raise rather than silently dropping the credential.
+        def fn(a, client_secret=None):
+            return a, client_secret
+
+        _accepts.cache_clear()
+        with patch("chuk_mcp_server.oauth.compat.inspect.signature", side_effect=ValueError):
+            assert supports_keyword(fn, "client_secret")
+        _accepts.cache_clear()
+
+    def test_different_instances_share_result(self):
+        # Caching keys on the underlying function, not the bound instance.
+        assert supports_keyword(ModernProvider().exchange, "client_secret")
+        assert supports_keyword(ModernProvider().exchange, "client_secret")
+        assert not supports_keyword(LegacyProvider().exchange, "client_secret")
+
+    def test_unhashable_callable(self):
+        class Unhashable:
+            __hash__ = None  # type: ignore[assignment]
+
+            def __call__(self, a, client_secret=None):
+                return a, client_secret
+
+        assert supports_keyword(Unhashable(), "client_secret")

--- a/tests/oauth/test_crypto.py
+++ b/tests/oauth/test_crypto.py
@@ -1,0 +1,40 @@
+"""Tests for constant-time credential comparison."""
+
+from chuk_mcp_server.oauth.crypto import secure_compare
+
+
+class TestSecureCompare:
+    """secure_compare must accept any input and never raise."""
+
+    def test_equal_values(self):
+        assert secure_compare("s3cret", "s3cret")
+
+    def test_different_values(self):
+        assert not secure_compare("s3cret", "other")
+
+    def test_empty_strings_are_equal(self):
+        assert secure_compare("", "")
+
+    def test_empty_versus_value(self):
+        assert not secure_compare("s3cret", "")
+        assert not secure_compare("", "s3cret")
+
+    def test_none_is_never_equal(self):
+        assert not secure_compare(None, "s3cret")
+        assert not secure_compare("s3cret", None)
+        assert not secure_compare(None, None)
+
+    def test_non_ascii_does_not_raise(self):
+        # secrets.compare_digest rejects non-ASCII str; encoding first avoids it.
+        assert not secure_compare("s3cret", "pásswörd")
+        assert not secure_compare("pásswörd", "s3cret")
+
+    def test_equal_non_ascii_values(self):
+        assert secure_compare("pásswörd", "pásswörd")
+
+    def test_emoji(self):
+        assert secure_compare("🔐token", "🔐token")
+        assert not secure_compare("🔐token", "🔓token")
+
+    def test_differing_lengths(self):
+        assert not secure_compare("short", "a-much-longer-value")

--- a/tests/oauth/test_google_drive_provider_flows.py
+++ b/tests/oauth/test_google_drive_provider_flows.py
@@ -558,3 +558,112 @@ class TestProviderConstruction:
         assert isinstance(instance.token_store, TokenStore)
         assert instance.token_store.sandbox_id == "custom-sandbox"
         assert instance._pending_authorizations == {}
+
+
+class TestRedirectUriRegistrationHardening:
+    """Registration must not accept a URI the callback page would render as a link."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "javascript:alert(document.cookie)",
+            "data:text/html,<script>alert(1)</script>",
+            "vbscript:msgbox(1)",
+            "file:///etc/passwd",
+            "/relative/callback",
+            "   ",
+        ],
+    )
+    async def test_dangerous_redirect_uris_are_rejected(self, provider, uri):
+        with pytest.raises(RegistrationError) as exc:
+            await provider.register_client({"client_name": "App", "redirect_uris": [uri]})
+
+        assert exc.value.error == ERROR_INVALID_REDIRECT_URI
+
+    @pytest.mark.asyncio
+    async def test_one_bad_uri_rejects_the_whole_registration(self, provider, store):
+        with pytest.raises(RegistrationError):
+            await provider.register_client(
+                {"client_name": "App", "redirect_uris": [REDIRECT_URI, "javascript:alert(1)"]}
+            )
+
+        assert store.registered == []
+
+    @pytest.mark.asyncio
+    async def test_non_string_redirect_uri_is_rejected(self, provider):
+        with pytest.raises(RegistrationError) as exc:
+            await provider.register_client({"client_name": "App", "redirect_uris": [{"not": "a string"}]})
+
+        assert exc.value.error == ERROR_INVALID_REDIRECT_URI
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "uri",
+        ["https://app.example/callback", "http://localhost:9999/callback", "com.example.app:/cb"],
+    )
+    async def test_navigable_uris_are_accepted(self, provider, uri):
+        info = await provider.register_client({"client_name": "App", "redirect_uris": [uri]})
+
+        assert info.redirect_uris == [uri]
+
+
+class TestAccessTokenLifetime:
+    """expires_in must match the TTL the token store actually applies."""
+
+    @pytest.mark.asyncio
+    async def test_reports_the_stores_ttl(self, provider, store):
+        store.access_token_ttl = 900
+        store.validate_code_result = {"user_id": USER_ID, "scope": None}
+
+        token = await provider.exchange_authorization_code(
+            code="the-code", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI
+        )
+
+        assert token.expires_in == 900
+
+    @pytest.mark.asyncio
+    async def test_refresh_reports_the_stores_ttl(self, provider, store):
+        store.access_token_ttl = 900
+
+        token = await provider.exchange_refresh_token(refresh_token="the-token", client_id=CLIENT_ID)
+
+        assert token.expires_in == 900
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_the_store_has_no_ttl(self, provider, store):
+        store.validate_code_result = {"user_id": USER_ID, "scope": None}
+
+        token = await provider.exchange_authorization_code(
+            code="the-code", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI
+        )
+
+        assert token.expires_in == 3600
+
+
+class TestValidateRedirectUriHook:
+    """The default hook answers from the token store, and fails closed."""
+
+    @pytest.mark.asyncio
+    async def test_registered_pairing_is_accepted(self, provider, store):
+        store.authenticate_result = True
+
+        assert await provider.validate_redirect_uri(CLIENT_ID, REDIRECT_URI)
+
+    @pytest.mark.asyncio
+    async def test_unregistered_pairing_is_rejected(self, provider, store):
+        store.authenticate_result = False
+
+        assert not await provider.validate_redirect_uri(CLIENT_ID, "http://evil.example/cb")
+
+    @pytest.mark.asyncio
+    async def test_a_raising_store_fails_closed(self, provider):
+        provider.token_store.validate_client = AsyncMock(side_effect=RuntimeError("store down"))
+
+        assert not await provider.validate_redirect_uri(CLIENT_ID, REDIRECT_URI)
+
+    @pytest.mark.asyncio
+    async def test_a_provider_without_a_token_store_fails_closed(self, provider):
+        del provider.token_store
+
+        assert not await provider.validate_redirect_uri(CLIENT_ID, REDIRECT_URI)

--- a/tests/oauth/test_google_drive_provider_flows.py
+++ b/tests/oauth/test_google_drive_provider_flows.py
@@ -1,0 +1,560 @@
+"""
+Tests for GoogleDriveOAuthProvider's OAuth Authorization Server behaviour.
+
+Covers the MCP-side flows — authorize, token exchange, refresh, token validation,
+client registration and the Google callback — against a fake token store, so no
+Google credentials or network access are needed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from chuk_mcp_server.oauth.constants import (
+    AUTH_METHOD_CLIENT_SECRET_BASIC,
+    AUTH_METHOD_CLIENT_SECRET_POST,
+    AUTH_METHOD_NONE,
+    ERROR_INVALID_CLIENT,
+    ERROR_INVALID_CLIENT_METADATA,
+    ERROR_INVALID_GRANT,
+    ERROR_INVALID_REDIRECT_URI,
+    ERROR_INVALID_TOKEN,
+    PROVIDER_GOOGLE_DRIVE,
+)
+from chuk_mcp_server.oauth.models import (
+    AuthorizationParams,
+    AuthorizeError,
+    RegistrationError,
+    TokenError,
+)
+
+REDIRECT_URI = "http://localhost:9999/callback"
+USER_ID = "google-user-1"
+CLIENT_ID = "client-a"
+CLIENT_SECRET = "client-a-secret"
+
+
+class FakeTokenStore:
+    """In-memory token store implementing the current interface."""
+
+    sandbox_id = "test-sandbox"
+
+    def __init__(self):
+        self.clients: dict[str, dict] = {}
+        self.codes: dict[str, dict] = {}
+        self.external: dict[str, dict] = {}
+        self.external_expired = False
+        self.access_tokens: dict[str, dict] = {}
+        self.authenticate_result = True
+        self.validate_code_result: dict | None = None
+        self.refresh_result: tuple[str, str] | None = ("new-access", "new-refresh")
+        self.refresh_calls: list[tuple] = []
+        self.registered: list[dict] = []
+        self.linked: list[dict] = []
+        self.created_codes: list[dict] = []
+        self.updated_external: list[dict] = []
+
+    async def register_client(self, client_name, redirect_uris, token_endpoint_auth_method=AUTH_METHOD_NONE):
+        self.registered.append(
+            {
+                "client_name": client_name,
+                "redirect_uris": redirect_uris,
+                "token_endpoint_auth_method": token_endpoint_auth_method,
+            }
+        )
+        return {
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+            "token_endpoint_auth_method": token_endpoint_auth_method,
+        }
+
+    async def validate_client(self, client_id, client_secret=None, redirect_uri=None):
+        return self.authenticate_result
+
+    async def authenticate_client(self, client_id, client_secret=None, redirect_uri=None):
+        return self.authenticate_result
+
+    async def validate_authorization_code(self, code, client_id, redirect_uri, code_verifier=None):
+        return self.validate_code_result
+
+    async def create_authorization_code(
+        self, user_id, client_id, redirect_uri, scope=None, code_challenge=None, code_challenge_method=None
+    ):
+        self.created_codes.append(
+            {
+                "user_id": user_id,
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "scope": scope,
+                "code_challenge": code_challenge,
+                "code_challenge_method": code_challenge_method,
+            }
+        )
+        return "issued-code"
+
+    async def create_access_token(self, user_id, client_id, scope=None):
+        return ("issued-access", "issued-refresh")
+
+    async def validate_access_token(self, token):
+        return self.access_tokens.get(token)
+
+    async def refresh_access_token(self, refresh_token, client_id=None):
+        self.refresh_calls.append((refresh_token, client_id))
+        return self.refresh_result
+
+    async def get_external_token(self, user_id, provider="external"):
+        return self.external.get(user_id)
+
+    async def is_external_token_expired(self, user_id, provider="external"):
+        return self.external_expired
+
+    async def link_external_token(self, user_id, access_token, refresh_token=None, expires_in=None, provider=None):
+        self.linked.append({"user_id": user_id, "access_token": access_token, "provider": provider})
+        self.external[user_id] = {"access_token": access_token, "refresh_token": refresh_token}
+
+    async def update_external_token(self, user_id, access_token, refresh_token=None, expires_in=None, provider=None):
+        self.updated_external.append({"user_id": user_id, "access_token": access_token})
+        self.external[user_id] = {"access_token": access_token, "refresh_token": refresh_token}
+
+
+class LegacyTokenStore(FakeTokenStore):
+    """A token store predating client-bound refresh and auth-method registration."""
+
+    async def register_client(self, client_name, redirect_uris):
+        self.registered.append({"client_name": client_name, "redirect_uris": redirect_uris})
+        return {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET}
+
+    async def refresh_access_token(self, refresh_token):
+        self.refresh_calls.append((refresh_token,))
+        return self.refresh_result
+
+    # Predates authenticate_client entirely.
+    authenticate_client = None
+
+
+@pytest.fixture
+def store():
+    return FakeTokenStore()
+
+
+@pytest.fixture
+def provider(store):
+    """A provider wired to the fake store, with the Google client stubbed."""
+    with patch("chuk_mcp_server.oauth.providers.google_drive.httpx", MagicMock()):
+        from chuk_mcp_server.oauth.providers.google_drive import GoogleDriveOAuthProvider
+
+        instance = GoogleDriveOAuthProvider(
+            google_client_id="google-id",
+            google_client_secret="google-secret",
+            google_redirect_uri="http://localhost:8000/oauth/callback",
+            token_store=store,
+        )
+    instance.google_client = Mock()
+    instance.google_client.get_authorization_url = Mock(return_value="https://accounts.google.com/auth?state=x")
+    return instance
+
+
+def auth_params(**overrides):
+    return AuthorizationParams(
+        response_type="code",
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        **overrides,
+    )
+
+
+class TestAuthorize:
+    """authorize() validates the client and routes to Google when needed."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_client(self, provider, store):
+        store.authenticate_result = False
+
+        with pytest.raises(AuthorizeError) as exc:
+            await provider.authorize(auth_params())
+
+        assert exc.value.error == ERROR_INVALID_CLIENT
+
+    @pytest.mark.asyncio
+    async def test_redirects_to_google_when_not_linked(self, provider):
+        result = await provider.authorize(auth_params(state="mcp-state"))
+
+        assert result["requires_external_authorization"] is True
+        assert result["authorization_url"].startswith("https://accounts.google.com/")
+        assert result["state"] in provider._pending_authorizations
+
+    @pytest.mark.asyncio
+    async def test_pending_authorization_records_client_details(self, provider):
+        result = await provider.authorize(
+            auth_params(state="mcp-state", scope="drive", code_challenge="chal", code_challenge_method="S256")
+        )
+
+        pending = provider._pending_authorizations[result["state"]]
+        assert pending["mcp_client_id"] == CLIENT_ID
+        assert pending["mcp_redirect_uri"] == REDIRECT_URI
+        assert pending["mcp_state"] == "mcp-state"
+        assert pending["mcp_scope"] == "drive"
+        assert pending["mcp_code_challenge"] == "chal"
+        assert pending["mcp_code_challenge_method"] == "S256"
+
+    @pytest.mark.asyncio
+    async def test_issues_code_when_already_linked(self, provider, store):
+        provider._pending_authorizations["mcp-state"] = {"user_id": USER_ID}
+        store.external[USER_ID] = {"access_token": "google-token"}
+
+        result = await provider.authorize(auth_params(state="mcp-state", scope="drive"))
+
+        assert result["code"] == "issued-code"
+        assert result["state"] == "mcp-state"
+        # The pending entry is consumed.
+        assert "mcp-state" not in provider._pending_authorizations
+        assert store.created_codes[0]["user_id"] == USER_ID
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_google_when_link_expired(self, provider, store):
+        provider._pending_authorizations["mcp-state"] = {"user_id": USER_ID}
+        store.external[USER_ID] = {"access_token": "google-token"}
+        store.external_expired = True
+
+        result = await provider.authorize(auth_params(state="mcp-state"))
+
+        assert result["requires_external_authorization"] is True
+
+
+class TestExchangeAuthorizationCode:
+    """Token exchange authenticates the client, then validates the code."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_unauthenticated_client(self, provider, store):
+        store.authenticate_result = False
+
+        with pytest.raises(TokenError) as exc:
+            await provider.exchange_authorization_code(
+                code="the-code", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI, client_secret="wrong"
+            )
+
+        assert exc.value.error == ERROR_INVALID_CLIENT
+
+    @pytest.mark.asyncio
+    async def test_client_is_authenticated_before_the_code_is_consumed(self, provider, store):
+        store.authenticate_result = False
+        store.validate_code_result = {"user_id": USER_ID, "scope": None}
+
+        with pytest.raises(TokenError):
+            await provider.exchange_authorization_code(code="the-code", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI)
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_code(self, provider, store):
+        store.validate_code_result = None
+
+        with pytest.raises(TokenError) as exc:
+            await provider.exchange_authorization_code(code="the-code", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI)
+
+        assert exc.value.error == ERROR_INVALID_GRANT
+
+    @pytest.mark.asyncio
+    async def test_issues_tokens_for_a_valid_code(self, provider, store):
+        store.validate_code_result = {"user_id": USER_ID, "scope": "drive"}
+
+        token = await provider.exchange_authorization_code(
+            code="the-code",
+            client_id=CLIENT_ID,
+            redirect_uri=REDIRECT_URI,
+            client_secret=CLIENT_SECRET,
+        )
+
+        assert token.access_token == "issued-access"
+        assert token.refresh_token == "issued-refresh"
+        assert token.token_type == "Bearer"
+        assert token.scope == "drive"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_validate_client_on_legacy_stores(self, provider):
+        provider.token_store = LegacyTokenStore()
+        provider.token_store.validate_code_result = {"user_id": USER_ID, "scope": None}
+
+        token = await provider.exchange_authorization_code(
+            code="the-code", client_id=CLIENT_ID, redirect_uri=REDIRECT_URI
+        )
+
+        assert token.access_token == "issued-access"
+
+
+class TestExchangeRefreshToken:
+    """Refresh authenticates the client and binds the token to it."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_unauthenticated_client(self, provider, store):
+        store.authenticate_result = False
+
+        with pytest.raises(TokenError) as exc:
+            await provider.exchange_refresh_token(refresh_token="the-token", client_id=CLIENT_ID)
+
+        assert exc.value.error == ERROR_INVALID_CLIENT
+
+    @pytest.mark.asyncio
+    async def test_passes_client_id_to_the_store(self, provider, store):
+        await provider.exchange_refresh_token(refresh_token="the-token", client_id=CLIENT_ID)
+
+        assert store.refresh_calls == [("the-token", CLIENT_ID)]
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_refresh_token(self, provider, store):
+        store.refresh_result = None
+
+        with pytest.raises(TokenError) as exc:
+            await provider.exchange_refresh_token(refresh_token="the-token", client_id=CLIENT_ID)
+
+        assert exc.value.error == ERROR_INVALID_GRANT
+
+    @pytest.mark.asyncio
+    async def test_returns_rotated_tokens(self, provider):
+        token = await provider.exchange_refresh_token(refresh_token="the-token", client_id=CLIENT_ID, scope="drive")
+
+        assert token.access_token == "new-access"
+        assert token.refresh_token == "new-refresh"
+        assert token.scope == "drive"
+
+    @pytest.mark.asyncio
+    async def test_legacy_store_is_called_without_client_id(self, provider, caplog):
+        provider.token_store = LegacyTokenStore()
+
+        token = await provider.exchange_refresh_token(refresh_token="the-token", client_id=CLIENT_ID)
+
+        assert provider.token_store.refresh_calls == [("the-token",)]
+        assert token.access_token == "new-access"
+        assert "client-bound refresh" in caplog.text
+
+
+class TestValidateAccessToken:
+    """Access token validation also surfaces the linked Google token."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_token(self, provider):
+        with pytest.raises(TokenError) as exc:
+            await provider.validate_access_token("nope")
+
+        assert exc.value.error == ERROR_INVALID_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_requires_a_linked_google_account(self, provider, store):
+        store.access_tokens["good"] = {"user_id": USER_ID, "client_id": CLIENT_ID}
+
+        with pytest.raises(TokenError) as exc:
+            await provider.validate_access_token("good")
+
+        assert exc.value.error == "insufficient_scope"
+
+    @pytest.mark.asyncio
+    async def test_returns_external_token(self, provider, store):
+        store.access_tokens["good"] = {"user_id": USER_ID, "client_id": CLIENT_ID}
+        store.external[USER_ID] = {"access_token": "google-token", "refresh_token": "google-refresh"}
+
+        result = await provider.validate_access_token("good")
+
+        assert result["user_id"] == USER_ID
+        assert result["external_access_token"] == "google-token"
+        assert result["external_refresh_token"] == "google-refresh"
+
+    @pytest.mark.asyncio
+    async def test_refreshes_an_expired_google_token(self, provider, store):
+        store.access_tokens["good"] = {"user_id": USER_ID, "client_id": CLIENT_ID}
+        store.external[USER_ID] = {"access_token": "old-token", "refresh_token": "google-refresh"}
+        store.external_expired = True
+        provider.google_client.refresh_access_token = AsyncMock(
+            return_value={"access_token": "fresh-token", "expires_in": 3600}
+        )
+
+        result = await provider.validate_access_token("good")
+
+        assert result["external_access_token"] == "fresh-token"
+        assert store.updated_external[0]["access_token"] == "fresh-token"
+
+    @pytest.mark.asyncio
+    async def test_expired_without_refresh_token_fails(self, provider, store):
+        store.access_tokens["good"] = {"user_id": USER_ID, "client_id": CLIENT_ID}
+        store.external[USER_ID] = {"access_token": "old-token"}
+        store.external_expired = True
+
+        with pytest.raises(TokenError) as exc:
+            await provider.validate_access_token("good")
+
+        assert exc.value.error == ERROR_INVALID_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_google_refresh_failure_is_reported(self, provider, store):
+        store.access_tokens["good"] = {"user_id": USER_ID, "client_id": CLIENT_ID}
+        store.external[USER_ID] = {"access_token": "old-token", "refresh_token": "google-refresh"}
+        store.external_expired = True
+        provider.google_client.refresh_access_token = AsyncMock(side_effect=RuntimeError("google is down"))
+
+        with pytest.raises(TokenError) as exc:
+            await provider.validate_access_token("good")
+
+        assert exc.value.error == ERROR_INVALID_TOKEN
+
+
+class TestRegisterClient:
+    """Registration honours the client's declared auth method."""
+
+    @pytest.mark.asyncio
+    async def test_requires_a_redirect_uri(self, provider):
+        with pytest.raises(RegistrationError) as exc:
+            await provider.register_client({"client_name": "App"})
+
+        assert exc.value.error == ERROR_INVALID_REDIRECT_URI
+
+    @pytest.mark.asyncio
+    async def test_undeclared_client_registers_as_public(self, provider, store):
+        info = await provider.register_client({"client_name": "App", "redirect_uris": [REDIRECT_URI]})
+
+        assert info.token_endpoint_auth_method == AUTH_METHOD_NONE
+        assert store.registered[0]["token_endpoint_auth_method"] == AUTH_METHOD_NONE
+
+    @pytest.mark.asyncio
+    async def test_declared_method_is_forwarded(self, provider, store):
+        info = await provider.register_client(
+            {
+                "client_name": "App",
+                "redirect_uris": [REDIRECT_URI],
+                "token_endpoint_auth_method": AUTH_METHOD_CLIENT_SECRET_POST,
+            }
+        )
+
+        assert info.token_endpoint_auth_method == AUTH_METHOD_CLIENT_SECRET_POST
+        assert store.registered[0]["token_endpoint_auth_method"] == AUTH_METHOD_CLIENT_SECRET_POST
+
+    @pytest.mark.asyncio
+    async def test_basic_method_is_forwarded(self, provider, store):
+        await provider.register_client(
+            {
+                "client_name": "App",
+                "redirect_uris": [REDIRECT_URI],
+                "token_endpoint_auth_method": AUTH_METHOD_CLIENT_SECRET_BASIC,
+            }
+        )
+
+        assert store.registered[0]["token_endpoint_auth_method"] == AUTH_METHOD_CLIENT_SECRET_BASIC
+
+    @pytest.mark.asyncio
+    async def test_unsupported_method_is_rejected(self, provider):
+        with pytest.raises(RegistrationError) as exc:
+            await provider.register_client(
+                {
+                    "client_name": "App",
+                    "redirect_uris": [REDIRECT_URI],
+                    "token_endpoint_auth_method": "private_key_jwt",
+                }
+            )
+
+        assert exc.value.error == ERROR_INVALID_CLIENT_METADATA
+
+    @pytest.mark.asyncio
+    async def test_returns_credentials(self, provider):
+        info = await provider.register_client({"client_name": "App", "redirect_uris": [REDIRECT_URI]})
+
+        assert info.client_id == CLIENT_ID
+        assert info.client_secret == CLIENT_SECRET
+        assert info.client_name == "App"
+        assert info.redirect_uris == [REDIRECT_URI]
+
+    @pytest.mark.asyncio
+    async def test_legacy_store_registers_public_clients(self, provider):
+        provider.token_store = LegacyTokenStore()
+
+        info = await provider.register_client({"client_name": "App", "redirect_uris": [REDIRECT_URI]})
+
+        assert info.token_endpoint_auth_method == AUTH_METHOD_NONE
+
+    @pytest.mark.asyncio
+    async def test_legacy_store_refuses_confidential_clients(self, provider):
+        # Better to refuse than to issue a secret that could never be enforced.
+        provider.token_store = LegacyTokenStore()
+
+        with pytest.raises(RegistrationError) as exc:
+            await provider.register_client(
+                {
+                    "client_name": "App",
+                    "redirect_uris": [REDIRECT_URI],
+                    "token_endpoint_auth_method": AUTH_METHOD_CLIENT_SECRET_POST,
+                }
+            )
+
+        assert exc.value.error == ERROR_INVALID_CLIENT_METADATA
+
+
+class TestHandleExternalCallback:
+    """The Google callback links the account and mints an MCP code."""
+
+    def _pending(self, provider, state="google-state"):
+        provider._pending_authorizations[state] = {
+            "mcp_client_id": CLIENT_ID,
+            "mcp_redirect_uri": REDIRECT_URI,
+            "mcp_state": "mcp-state",
+            "mcp_scope": "drive",
+            "mcp_code_challenge": "chal",
+            "mcp_code_challenge_method": "S256",
+        }
+        return state
+
+    @pytest.mark.asyncio
+    async def test_unknown_state_is_rejected(self, provider):
+        with pytest.raises(ValueError, match="Invalid or expired state"):
+            await provider.handle_external_callback("google-code", "unknown-state")
+
+    @pytest.mark.asyncio
+    async def test_google_token_exchange_failure(self, provider):
+        state = self._pending(provider)
+        provider.google_client.exchange_code_for_token = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(ValueError, match="Google token exchange failed"):
+            await provider.handle_external_callback("google-code", state)
+
+    @pytest.mark.asyncio
+    async def test_user_info_failure(self, provider):
+        state = self._pending(provider)
+        provider.google_client.exchange_code_for_token = AsyncMock(return_value={"access_token": "g-token"})
+        provider.google_client.get_user_info = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(ValueError, match="Failed to get Google user info"):
+            await provider.handle_external_callback("google-code", state)
+
+    @pytest.mark.asyncio
+    async def test_successful_callback(self, provider, store):
+        state = self._pending(provider)
+        provider.google_client.exchange_code_for_token = AsyncMock(
+            return_value={"access_token": "g-token", "refresh_token": "g-refresh", "expires_in": 3600}
+        )
+        provider.google_client.get_user_info = AsyncMock(return_value={"sub": USER_ID})
+
+        result = await provider.handle_external_callback("google-code", state)
+
+        assert result["code"] == "issued-code"
+        assert result["state"] == "mcp-state"
+        assert result["redirect_uri"] == REDIRECT_URI
+        assert store.linked[0]["user_id"] == USER_ID
+        assert store.linked[0]["provider"] == PROVIDER_GOOGLE_DRIVE
+        # The PKCE challenge from the original request is carried through.
+        assert store.created_codes[0]["code_challenge"] == "chal"
+        assert store.created_codes[0]["code_challenge_method"] == "S256"
+        assert state not in provider._pending_authorizations
+
+
+class TestProviderConstruction:
+    """Constructor wiring."""
+
+    def test_creates_a_default_token_store(self):
+        with patch("chuk_mcp_server.oauth.providers.google_drive.httpx", MagicMock()):
+            from chuk_mcp_server.oauth.providers.google_drive import GoogleDriveOAuthProvider
+            from chuk_mcp_server.oauth.token_store import TokenStore
+
+            instance = GoogleDriveOAuthProvider(
+                google_client_id="google-id",
+                google_client_secret="google-secret",
+                google_redirect_uri="http://localhost:8000/oauth/callback",
+                sandbox_id="custom-sandbox",
+            )
+
+        assert isinstance(instance.token_store, TokenStore)
+        assert instance.token_store.sandbox_id == "custom-sandbox"
+        assert instance._pending_authorizations == {}

--- a/tests/oauth/test_middleware.py
+++ b/tests/oauth/test_middleware.py
@@ -26,12 +26,18 @@ class MockOAuthProvider(BaseOAuthProvider):
     provider that accepts client_secret.
     """
 
-    def __init__(self):
+    def __init__(self, redirect_uri_registered=True):
         self.authorize_called = False
         self.exchange_code_called = False
         self.exchange_refresh_called = False
         self.validate_token_called = False
         self.register_client_called = False
+        self.redirect_uri_registered = redirect_uri_registered
+
+    async def validate_redirect_uri(self, client_id, redirect_uri):
+        # Treat the test client's redirect URI as registered so error-redirect
+        # behaviour can be exercised; flip the flag to test the refusal path.
+        return self.redirect_uri_registered
 
     async def authorize(self, params):
         self.authorize_called = True

--- a/tests/oauth/test_middleware.py
+++ b/tests/oauth/test_middleware.py
@@ -18,7 +18,13 @@ from chuk_mcp_server.oauth.models import (
 
 
 class MockOAuthProvider(BaseOAuthProvider):
-    """Mock OAuth provider for testing."""
+    """Mock OAuth provider for testing.
+
+    Deliberately keeps the pre-client-authentication method signatures so these
+    tests also cover the middleware's backwards-compatibility path for providers
+    written against an earlier release. See TestClientAuthentication for a
+    provider that accepts client_secret.
+    """
 
     def __init__(self):
         self.authorize_called = False
@@ -274,6 +280,7 @@ class TestOAuthMiddleware:
             "redirect_uri": "http://localhost/callback",
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -304,6 +311,7 @@ class TestOAuthMiddleware:
             "client_id": "test_client",
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -327,6 +335,7 @@ class TestOAuthMiddleware:
             "grant_type": "unsupported_grant",
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -355,6 +364,7 @@ class TestOAuthMiddleware:
             # Missing code, client_id, redirect_uri
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -419,9 +429,10 @@ class TestOAuthMiddleware:
         import json
 
         body = json.loads(response.body)
-        # Middleware wraps all exceptions as invalid_client_metadata with sanitized description
-        assert body["error"] == "invalid_client_metadata"
-        assert body["error_description"] == "Client registration failed"
+        # RegistrationError carries an RFC 7591 error code, which is surfaced as-is
+        # so the client can tell why registration was refused.
+        assert body["error"] == "invalid_redirect_uri"
+        assert body["error_description"] == "Invalid redirect URI"
 
     @pytest.mark.asyncio
     async def test_external_callback_success(self):
@@ -578,6 +589,7 @@ class TestOAuthMiddleware:
             "code_verifier": "test_verifier",
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -609,6 +621,7 @@ class TestOAuthMiddleware:
             "redirect_uri": "http://localhost/callback",
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -617,7 +630,9 @@ class TestOAuthMiddleware:
         import json
 
         body = json.loads(response.body)
-        assert body["error"] == "invalid_request"
+        # A TokenError's own code is surfaced; the description stays sanitized.
+        assert body["error"] == "invalid_grant"
+        assert body["error_description"] == "Token exchange failed"
 
     @pytest.mark.asyncio
     async def test_authorize_with_state(self):
@@ -774,6 +789,7 @@ class TestOAuthMiddleware:
             # Missing refresh_token
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -792,6 +808,7 @@ class TestOAuthMiddleware:
             # Missing client_id
         }
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {}
 
         response = await middleware._token_endpoint(mock_request)
 
@@ -890,6 +907,7 @@ class TestOAuthMiddleware:
         assert isinstance(response, RedirectResponse)
 
         # Call token endpoint through registered function
+        mock_request.headers = {}
         mock_request.form = AsyncMock(
             return_value={
                 "grant_type": "authorization_code",

--- a/tests/oauth/test_providers_init.py
+++ b/tests/oauth/test_providers_init.py
@@ -1,0 +1,33 @@
+"""Tests for optional provider exports."""
+
+import builtins
+import importlib
+
+import chuk_mcp_server.oauth.providers as providers
+
+
+class TestProviderExports:
+    """The provider package degrades gracefully without optional dependencies."""
+
+    def test_google_drive_is_exported_when_importable(self):
+        module = importlib.reload(providers)
+
+        assert "GoogleDriveOAuthProvider" in module.__all__
+        assert "GoogleDriveOAuthClient" in module.__all__
+
+    def test_missing_dependencies_leave_exports_empty(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def fail_google_drive(name, globals=None, locals=None, fromlist=(), level=0):
+            if "google_drive" in name:
+                raise ImportError("httpx is not installed")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fail_google_drive)
+        module = importlib.reload(providers)
+
+        assert module.__all__ == []
+
+    def teardown_method(self):
+        # Restore the real exports for any test that runs afterwards.
+        importlib.reload(providers)

--- a/tests/oauth/test_redirect_uri.py
+++ b/tests/oauth/test_redirect_uri.py
@@ -1,0 +1,81 @@
+"""Tests for redirect URI validation and construction."""
+
+import pytest
+
+from chuk_mcp_server.oauth.redirect_uri import build_redirect_url, is_safe_redirect_uri
+
+
+class TestIsSafeRedirectUri:
+    """Only absolute URIs with a navigable scheme may be registered."""
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "https://app.example/callback",
+            "http://localhost:9999/callback",
+            "http://127.0.0.1:8080/cb",
+            "https://app.example/cb?existing=1",
+            "com.example.app:/oauth/callback",
+            "myapp://callback",
+        ],
+    )
+    def test_accepts_navigable_uris(self, uri):
+        assert is_safe_redirect_uri(uri)
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "  javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "vbscript:msgbox(1)",
+            "file:///etc/passwd",
+            "blob:https://app.example/uuid",
+            "about:blank",
+        ],
+    )
+    def test_rejects_executable_schemes(self, uri):
+        assert not is_safe_redirect_uri(uri)
+
+    @pytest.mark.parametrize("uri", ["", "   ", "/callback", "callback", "//app.example/cb"])
+    def test_rejects_non_absolute_uris(self, uri):
+        assert not is_safe_redirect_uri(uri)
+
+    def test_rejects_scheme_with_no_target(self):
+        assert not is_safe_redirect_uri("https:")
+
+    def test_rejects_unparseable_uri(self):
+        # An invalid IPv6 literal makes urlparse raise.
+        assert not is_safe_redirect_uri("https://[oops/cb")
+
+
+class TestBuildRedirectUrl:
+    """Parameters must be appended to whatever query string already exists."""
+
+    def test_appends_to_a_uri_without_a_query(self):
+        url = build_redirect_url("https://app.example/cb", {"code": "abc"})
+
+        assert url == "https://app.example/cb?code=abc"
+
+    def test_appends_to_a_uri_with_a_query(self):
+        # A second "?" would corrupt the URL and drop the code.
+        url = build_redirect_url("https://app.example/cb?tenant=acme", {"code": "abc"})
+
+        assert url == "https://app.example/cb?tenant=acme&code=abc"
+
+    def test_encodes_parameter_values(self):
+        url = build_redirect_url("https://app.example/cb", {"error_description": "Authorization failed"})
+
+        assert "Authorization+failed" in url
+        assert " " not in url
+
+    def test_no_params_returns_the_uri_unchanged(self):
+        assert build_redirect_url("https://app.example/cb", {}) == "https://app.example/cb"
+
+    def test_preserves_multiple_parameters(self):
+        url = build_redirect_url("https://app.example/cb", {"code": "abc", "state": "xyz"})
+
+        assert "code=abc" in url
+        assert "state=xyz" in url
+        assert url.count("?") == 1

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,7 @@ google-drive = [
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "pyasn1" },
 ]
 monitoring = [
     { name = "psutil" },
@@ -616,6 +617,7 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "psutil", marker = "extra == 'monitoring'", specifier = ">=7.0.0" },
+    { name = "pyasn1", marker = "extra == 'google-drive'", specifier = ">=0.6.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -2037,11 +2039,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "chuk-mcp-server"
-version = "0.25.6"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "chuk-mcp" },


### PR DESCRIPTION
## Summary

The OAuth token endpoint advertised `client_secret_post`/`client_secret_basic` in its RFC 8414 metadata and issued a real `client_secret` at every registration, but never read a secret from the request and never checked one. This branch closes that gap and the related issues found while fixing it.

## Changes

**Client authentication (`758e030`)**
- `_token_endpoint()` extracts `client_secret` from the request body or an `Authorization: Basic` header (RFC 6749 §2.3.1) and passes it to the provider
- `ClientData` persists the client's RFC 7591 `token_endpoint_auth_method`; `TokenStore.authenticate_client()` requires a secret from clients that registered as confidential and rejects a wrong secret from any client
- Refresh tokens are bound to their client — `refresh_access_token()` rejects a `client_id` mismatch (RFC 6749 §6). Previously a leaked refresh token was redeemable by anyone
- PKCE fails closed: an absent `code_challenge_method` means `plain` per RFC 7636 §4.3, and an unknown method is rejected. Previously a challenge sent without a method was never verified — any non-empty verifier passed
- `invalid_client` returns 401 with `WWW-Authenticate` (RFC 6749 §5.2)

**Redirect URI hardening (`05195b3`)**
- The authorization endpoint no longer redirects errors to an unvalidated `redirect_uri` (RFC 6749 §4.1.2.1). New `BaseOAuthProvider.validate_redirect_uri()` hook, defaulting to the provider's token store
- Registration rejects `javascript:`, `data:`, `vbscript:`, `file:`, `blob:`, `about:` and relative redirect URIs. The callback page renders the registered URI as a link, so these were a route to script execution on the server's origin
- `secure_compare()` replaces `secrets.compare_digest` on raw `str`, which raises `TypeError` on non-ASCII input
- Basic credentials use `unquote_plus` (RFC 6749 §2.3.1 is form-urlencoded)
- Redirect params append with `&` when the registered URI already has a query string; a second `?` previously corrupted the URL and lost the code
- `expires_in` reports the store's real TTL rather than a hardcoded 3600 against a 900s lifetime
- Authorization codes and access tokens are no longer partially logged

**Exports and version (`532ac63`)**
- `supports_keyword`, `secure_compare`, `is_safe_redirect_uri`, `build_redirect_url` exported for provider authors
- Version bumped to 0.26.0

## Backwards compatibility

New parameters are optional and defaulted. Clients registered before this change deserialize as public, so existing flows keep working. `supports_keyword` lets the middleware and provider detect older extension-point signatures and fall back.

Two deliberate behaviour changes:
- A `client_secret` sent to a provider that cannot verify it is **refused** rather than silently ignored — silently dropping the credential is the bug being fixed
- A provider with no `token_store` and no `validate_redirect_uri` override renders error pages where it previously redirected

`RegistrationError` and `TokenError` now surface their own RFC error codes instead of being flattened; descriptions stay sanitized.

## Testing

- 2655 passed, 17 skipped; ruff, mypy and bandit clean
- oauth module coverage 76% → 99%, every file above 97%
- New tests confirmed to fail against the pre-fix code (41 across both commits)
- Spot-checked 12 downstream MCP servers: results byte-identical to `main` in every case. `chuk-mcp-linkedin` (the only OAuth consumer, with three out-of-tree providers on the old signatures) passes all 1058 of its tests unchanged