### PR TITLE
fix(ci): break concurrency deadlock between publish.yml and ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, not github.workflow: when this workflow is called by
+  # publish.yml, github.workflow resolves to the CALLER's name, so a shared
+  # expression makes caller and callee collide and the run deadlocks.
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Must not collide with the group used by the ci.yml workflow this calls.
+  group: publish-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Problem

Every tag- and release-triggered publish has failed within seconds since at least v0.25.5:

| Run | Trigger | Result |
|---|---|---|
| v0.26.0 | tag push | failure (8s) |
| v0.25.6 | workflow_dispatch (tests on) | failure (3s) |
| v0.25.6 | workflow_dispatch (`skip_tests: true`) | success |
| v0.25.5 | release published | failure (1s) |

In each failure `Build Distribution` and `Publish to PyPI` report `skipped` and the reusable `test` job never appears at all. The only successful runs are the ones that skip tests — precisely the path that does not call `ci.yml`.

## Cause

Both workflows declared the same concurrency expression:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
```

In a **reusable** workflow, `github.workflow` resolves to the *caller's* name. So when `publish.yml` calls `ci.yml`, both groups evaluate to the identical string (`Publish to PyPI-refs/tags/v0.26.0`). The called workflow cannot start until its caller leaves the group, and the caller is blocked waiting on the called workflow — GitHub detects the deadlock and fails the run immediately.

This is why `skip_tests: true` was the only thing that ever worked: it skips the reusable call, so no collision occurs.

## Fix

Each workflow gets a literal prefix that cannot collide:

- `ci.yml` → `ci-${{ github.ref }}`
- `publish.yml` → `publish-${{ github.ref }}`
- `release.yml` → `release-${{ github.ref }}`

For reference, `chuk-artifacts` — whose releases do work — declares no concurrency groups at all.

## Verification

CI on this PR exercises `ci.yml` directly. The real proof is the next publish running its tests to completion instead of failing in under 10s.