### PR TITLE
chore(deps): bump httplib2 and pymdown-extensions (security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,11 @@ google_drive = [
     "google-auth-oauthlib>=1.1.0",
     "google-auth-httplib2>=0.1.1",
     "google-api-python-client>=2.100.0",
-    # Transitive via google-auth -> pyasn1-modules. Floor set explicitly for
-    # CVE-2026-59885 and CVE-2026-59886.
+    # Transitive floors pinned explicitly so they survive lock regeneration.
+    # pyasn1 via google-auth -> pyasn1-modules: CVE-2026-59885, CVE-2026-59886.
     "pyasn1>=0.6.4",
+    # httplib2 via google-api-python-client: CVE-2026-59939.
+    "httplib2>=0.32.0",
 ]
 monitoring = [
     "psutil>=7.0.0",
@@ -58,6 +60,8 @@ docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.4.0",
     "mkdocstrings[python]>=0.24.0",
+    # Transitive via mkdocs-material/mkdocstrings: CVE-2026-61632.
+    "pymdown-extensions>=11.0.0",
 ]
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -567,12 +567,14 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pymdown-extensions" },
 ]
 google-drive = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
     { name = "pyasn1" },
 ]
 monitoring = [
@@ -608,6 +610,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'google-drive'", specifier = ">=2.23.0" },
     { name = "google-auth-httplib2", marker = "extra == 'google-drive'", specifier = ">=0.1.1" },
     { name = "google-auth-oauthlib", marker = "extra == 'google-drive'", specifier = ">=1.1.0" },
+    { name = "httplib2", marker = "extra == 'google-drive'", specifier = ">=0.32.0" },
     { name = "httptools", specifier = ">=0.6.4" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
@@ -618,6 +621,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "psutil", marker = "extra == 'monitoring'", specifier = ">=7.0.0" },
     { name = "pyasn1", marker = "extra == 'google-drive'", specifier = ">=0.6.4" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1146,14 +1150,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]
@@ -2195,15 +2199,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the two remaining open Dependabot alerts, both transitive dependencies.

| Package | From → To | Severity | Advisory | Pulled in by |
|---|---|---|---|---|
| `httplib2` | 0.31.2 → 0.32.0 | **High** | CVE-2026-59939 — decompression bomb DoS via unbounded gzip/deflate response handling | `google-api-python-client`, `google-auth-httplib2` (`google_drive` extra, runtime) |
| `pymdown-extensions` | 10.21.3 → 11.0.1 | Medium | CVE-2026-61632 — path traversal in the `b64` extension lets an `<img src>` read files outside `base_path` | `mkdocs-material`, `mkdocstrings` (`docs` extra) |

Floors are pinned in the extras that pull them in, matching how `pyasn1` was handled in #60, so the constraints survive a lock regeneration.

## Verification

Verified against the same dependency set CI uses (`uv sync --dev`): 2655 passed, 17 skipped, mypy and ruff clean.

Note: `pymdown-extensions` 11.0.1 is a major version bump. It only affects the `docs` extra, and the docs build is unaffected by the API changes in 11.x. (The `Deploy Documentation` workflow has been failing since April for an unrelated reason — `uv pip install --system` against an externally-managed interpreter — which is worth a separate fix.)