### PR TITLE
deps: cap chuk-mcp below 0.10 (short-term, pure-Python)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dependencies = [
-    "chuk-mcp>=0.9.2",
+    # Cap below 0.10: the 0.10 line is the Rust-backed chuk-mcp that depends on
+    # chuk-mcp-rs, which is not published yet. Lift once chuk-mcp-rs is on PyPI.
+    "chuk-mcp>=0.9.2,<0.10",
     "chuk-sessions>=0.6.1",
     "chuk-tool-processor>=0.22.1", # Required for MCP proxy/tool handling
     "httptools>=0.6.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chuk-mcp-server"
-version = "0.26.0"
+version = "0.26.1"
 description = "A developer-friendly MCP framework powered by chuk_mcp"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Short-term guard: the chuk-mcp 0.10 line is the Rust-backed build that depends on the not-yet-published `chuk-mcp-rs`. Without a cap, a 0.10 release would be auto-resolved by `chuk-mcp>=0.9.2` and break installs.

Upper bound still allows 0.9.x patch/security releases. Lift once chuk-mcp-rs (and chuk-mcp 0.10) are published and validated.